### PR TITLE
Allow custom mappers

### DIFF
--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -28,5 +28,12 @@ module ROM
     def [](name)
       instance_variable_get("@#{name}")
     end
+
+    # Delegate unknown methods to the Coerced hash
+    #
+    # @api public
+    def method_missing(method, *args, &block)
+      to_h.send(method, *args, &block)
+    end
   end
 end

--- a/spec/integration/customer_mapper_spec.rb
+++ b/spec/integration/customer_mapper_spec.rb
@@ -1,0 +1,32 @@
+require 'ostruct'
+
+RSpec.describe 'Repository with a customer mapper' do
+  include_context 'database'
+  include_context 'relations'
+  include_context 'seeds'
+
+  let(:repo) { repo_class.new(rom) }
+  let(:repo_class) do
+    Class.new(ROM::Repository::Base) do
+      relations :users
+
+      def all_users
+        users.all
+      end
+    end
+  end
+
+  before do
+    setup.mappers do
+      define(:users) do
+        register_as :custom_user
+        model OpenStruct
+      end
+    end
+  end
+
+  it 'maps to my model' do
+    expect(repo.all_users.as(:custom_user).to_a).to be_an Array
+    expect(repo.all_users.as(:custom_user).to_a.first).to be_an OpenStruct
+  end
+end


### PR DESCRIPTION
In the README it states:

> Nothing is stopping you from decorating your structs using registered
> mappers and custom decorator models:

However this doesn't appear to work as advertised. 

I've added a failing integration spec and a fix, although I'm not entirely happy with the fix itself.

If you have a custom mapper and send to a non-virtus model it will fail. If you have
custom mapping inside your mapper eg:

``` ruby
  attribute :jsonb_column do |td|
    JSON.parse(td, symbolize_names: true)
  end
```

Then it fails in transproc. In both situations the process is:

```
Call method on repository
  |
  --> Calls relation view to retrieve data
      |
      --> Maps that using ROM Repository's mapper
          |
          --> ROM::Struct
              |
              --> calls `as(:custom_mapper)`
                  |
                  --> This mapper expects a hash, not a struct so blows up
```

It's not an ideal solution, but delegating method missing to the hash
fixes all these problems in the short term.
