### PR TITLE
Fix/materialization

### DIFF
--- a/lib/rom/repository/loading_proxy.rb
+++ b/lib/rom/repository/loading_proxy.rb
@@ -172,6 +172,11 @@ module ROM
           super
         end
       end
+
+      # @api private
+      def respond_to_missing?(meth, _include_private = false)
+        relation.respond_to?(meth) || super
+      end
     end
   end
 end

--- a/lib/rom/repository/loading_proxy.rb
+++ b/lib/rom/repository/loading_proxy.rb
@@ -159,9 +159,9 @@ module ROM
       #       and ROM::Lazy is gone
       #
       # @api private
-      def method_missing(meth, *args)
+      def method_missing(meth, *args, &block)
         if relation.respond_to?(meth)
-          result = relation.__send__(meth, *args)
+          result = relation.__send__(meth, *args, &block)
 
           if result.kind_of?(Relation::Materializable) && !result.is_a?(Relation::Loaded)
             __new__(result)

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe 'ROM repository' do
   include_context 'structs'
 
   it 'loads a single relation' do
-    expect(repo.all_users.to_a).to eql([jane, joe])
+    expect(repo.all_users.to_a).to match_array([jane, joe])
+  end
+
+  it 'loads a relation by an association' do
+    expect(repo.tasks_for_users(repo.all_users)).to match_array([jane_task, joe_task])
   end
 
   it 'loads a combine relation with one parent' do
@@ -17,15 +21,15 @@ RSpec.describe 'ROM repository' do
   end
 
   it 'loads a combined relation with many children' do
-    expect(repo.users_with_tasks.to_a).to eql([jane_with_tasks, joe_with_tasks])
+    expect(repo.users_with_tasks.to_a).to match_array([jane_with_tasks, joe_with_tasks])
   end
 
   it 'loads a combined relation with one child' do
-    expect(repo.users_with_task.to_a).to eql([jane_with_task, joe_with_task])
+    expect(repo.users_with_task.to_a).to match_array([jane_with_task, joe_with_task])
   end
 
   it 'loads a combined relation with one child restricted by given criteria' do
-    expect(repo.users_with_task_by_title('Joe Task').to_a).to eql([
+    expect(repo.users_with_task_by_title('Joe Task').to_a).to match_array([
       jane_without_task, joe_with_task
     ])
   end

--- a/spec/shared/repo.rb
+++ b/spec/shared/repo.rb
@@ -13,6 +13,10 @@ RSpec.shared_context('repo') do
         users.all
       end
 
+      def tasks_for_users(users)
+        tasks.for_users(users)
+      end
+
       def task_with_user
         tasks.find(id: 2).combine_parents(one: users)
       end


### PR DESCRIPTION
This PR fixes a bug with forwarding to a relation when a method takes a block (such as many enumerable methods - `map`, `select`, `reject` etc.)

With rom-sql this results in an error similar to the following:

``` ruby
def for_sessions(sessions)
  where(id: sessions.map { |session| session[:user_id] })
end

Sequel::Error: can't express #<Enumerator: #<Sequel::Postgres::Dataset: "SELECT * FROM \"sessions\" WHERE ((\"expires_at\" > '2015-10-14 16:31:38.350633+0100') AND (\"token\" = 'test')) LIMIT 1">:map> as a SQL literal
```

As calling such methods without a block returns an `Enumerator` rather than an `Array`
