### PR TITLE
[WIP] Introduce Repository::Model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,17 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'inflecto'
-
 group :test do
+  gem 'inflecto'
   gem 'anima', '~> 0.2.0'
   gem 'rom-sql', '~> 0.7.0'
   gem 'rspec'
   gem 'byebug', platforms: :mri
   gem 'pg', platforms: [:mri, :rbx]
   gem 'pg_jruby', platforms: :jruby
-  gem "codeclimate-test-reporter", require: nil
+  gem 'codeclimate-test-reporter', require: nil
 end
 
-gem 'benchmark-ips'
+group :tools do
+  gem 'pry'
+end

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'pry'
+require 'rom-repository'
+require 'rom/repository/model'
+
+def rom
+  @rom ||= ROM.container(:sql, db_url) do |config|
+    config.use(:macros)
+    config.relation(:users)
+  end
+end
+
+def db_url
+  ENV.fetch('DATABASE_URL', 'postgres://localhost/rom_repository')
+end
+
+Pry.start

--- a/lib/rom/repository/model.rb
+++ b/lib/rom/repository/model.rb
@@ -8,13 +8,22 @@ module ROM
 
       attr_reader :create_command
 
+      attr_reader :update_command
+
       def initialize(rom)
         super
         @create_command = Commands::Create[adapter].build(relation, result: :one)
+        @update_command = Commands::Update[adapter].build(relation, result: :one)
       end
 
       def create(attributes)
         create_command.call(attributes)
+      end
+
+      def update(pk, attributes)
+        update_command
+          .new(relation.where(relation.primary_key => pk))
+          .call(attributes)
       end
 
       private

--- a/lib/rom/repository/model.rb
+++ b/lib/rom/repository/model.rb
@@ -10,10 +10,13 @@ module ROM
 
       attr_reader :update_command
 
+      attr_reader :delete_command
+
       def initialize(rom)
         super
         @create_command = Commands::Create[adapter].build(relation, result: :one)
         @update_command = Commands::Update[adapter].build(relation, result: :one)
+        @delete_command = Commands::Delete[adapter].build(relation, result: :one)
       end
 
       def create(attributes)
@@ -24,6 +27,12 @@ module ROM
         update_command
           .new(relation.where(relation.primary_key => pk))
           .call(attributes)
+      end
+
+      def delete(pk)
+        delete_command
+          .new(relation.where(relation.primary_key => pk))
+          .call
       end
 
       private

--- a/lib/rom/repository/model.rb
+++ b/lib/rom/repository/model.rb
@@ -1,0 +1,35 @@
+module ROM
+  class Repository
+    class Model < Repository
+      def self.[](name)
+        klass = Class.new(self) { relations(name) }
+        klass
+      end
+
+      attr_reader :create_command
+
+      def initialize(rom)
+        super
+        @create_command = Commands::Create[adapter].build(relation, result: :one)
+      end
+
+      def create(attributes)
+        create_command.call(attributes)
+      end
+
+      private
+
+      def relation
+        __send__(relation_name).relation
+      end
+
+      def relation_name
+        self.class.relations[0]
+      end
+
+      def adapter
+        relation.class.adapter
+      end
+    end
+  end
+end

--- a/spec/integration/repository/model_spec.rb
+++ b/spec/integration/repository/model_spec.rb
@@ -1,0 +1,16 @@
+require 'rom/repository/model'
+
+RSpec.describe ROM::Repository::Model do
+  subject(:repo) { ROM::Repository::Model[:users].new(rom) }
+
+  include_context 'database'
+
+  describe '#create' do
+    it 'inserts tuple into relation' do
+      user_tuple = repo.create(name: 'Jane')
+      user_struct = repo.users.where(id: user_tuple[:id]).one
+
+      expect(user_struct.to_h).to eql(user_tuple)
+    end
+  end
+end

--- a/spec/integration/repository/model_spec.rb
+++ b/spec/integration/repository/model_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe ROM::Repository::Model do
 
   include_context 'database'
 
+  before do
+    configuration.relation(:users)
+  end
+
   describe '#create' do
     it 'inserts tuple into relation' do
       user_tuple = repo.create(name: 'Jane')

--- a/spec/integration/repository/model_spec.rb
+++ b/spec/integration/repository/model_spec.rb
@@ -25,4 +25,16 @@ RSpec.describe ROM::Repository::Model do
       expect(user_struct.name).to eql('Jane Doe')
     end
   end
+
+  describe '#delete' do
+    it 'deletes existing tuple from a relation' do
+      user_tuple = repo.create(name: 'Jane')
+
+      repo.delete(user_tuple[:id])
+
+      user_struct = repo.users.where(id: user_tuple[:id]).first
+
+      expect(user_struct).to be(nil)
+    end
+  end
 end

--- a/spec/integration/repository/model_spec.rb
+++ b/spec/integration/repository/model_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe ROM::Repository::Model do
       expect(user_struct.to_h).to eql(user_tuple)
     end
   end
+
+  describe '#update' do
+    it 'updates existing tuple in a relation' do
+      user_tuple = repo.create(name: 'Jane')
+
+      repo.update(user_tuple[:id], name: 'Jane Doe')
+
+      user_struct = repo.users.where(id: user_tuple[:id]).one
+
+      expect(user_struct.name).to eql('Jane Doe')
+    end
+  end
 end


### PR DESCRIPTION
This adds a new type of repo that is designed to provide a simple CRUD interface for a single "model" which maps directory to the canonical relation schema (ie a table in an sql db).

API:

``` ruby
class UserRepo < ROM::Repository::Model[:users]
end

user_repo = UserRepo.new(rom)

user_repo.create(name: 'Jane')

user_repo.update(1, name: 'Jane Doe')

user_repo.delete(1)
```

refs #13 
