### PR TITLE
Support command definition using block syntax

### DIFF
--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -11,13 +11,13 @@ module ROM
 
       def self.[](*args)
         cache.fetch_or_store(args.hash) do
-          container, type, adapter, ast = args
+          container, type, adapter, ast, block = args
 
           unless SUPPORTED_TYPES.include?(type)
             raise ArgumentError, "#{type.inspect} is not a supported command type"
           end
 
-          graph_opts = new(type, adapter, container, registry).visit(ast)
+          graph_opts = new(type, adapter, container, registry, block).visit(ast)
 
           command = ROM::Commands::Graph.build(registry, graph_opts)
 
@@ -37,12 +37,13 @@ module ROM
         @__registry__ ||= Hash.new { |h, k| h[k] = {} }
       end
 
-      attr_reader :type, :adapter, :container, :registry
+      attr_reader :type, :adapter, :container, :registry, :block
 
-      def initialize(type, adapter, container, registry)
+      def initialize(type, adapter, container, registry, block)
         @type = Commands.const_get(Inflector.classify(type))[adapter]
         @registry = registry
         @container = container
+        @block = block
       end
 
       def visit(ast)
@@ -99,6 +100,8 @@ module ROM
         end
 
         result = meta.fetch(:combine_type, :one)
+
+        klass.instance_exec(&block) if block
 
         registry[name][type] = klass.build(relation, result: result)
       end

--- a/spec/shared/plugins.rb
+++ b/spec/shared/plugins.rb
@@ -1,0 +1,22 @@
+RSpec.shared_context 'plugins' do
+  ROM.plugins do
+    adapter :sql do
+      upcase_name = Module.new do
+        def execute(tuples)
+          upcased = Array([tuples]).flatten.map do |t|
+            h = t.to_h
+            h.merge(name: h.fetch(:name).upcase)
+          end
+
+          if one?
+            super(upcased.first)
+          else
+            super(upcased)
+          end
+        end
+      end
+
+      register :upcase_name, upcase_name, type: :command
+    end
+  end
+end


### PR DESCRIPTION
Hi there!

I finally grabbed a fresh version with commands support.
My existing code relies on commands extensions pretty much, e.g. I added an extension for managing timestamp fields (aka created_at/updated_at). I think ability to pass a block to a command definition makes defining standalone commands almost completely unnecessary. What do you think?
