### PR TITLE
Support custom foreign keys

### DIFF
--- a/lib/rom/repository/relation_proxy/combine.rb
+++ b/lib/rom/repository/relation_proxy/combine.rb
@@ -53,13 +53,13 @@ module ROM
             h[type] =
               if parents.is_a?(Hash)
                 parents.each_with_object({}) { |(key, parent), r|
-                  r[key] = [parent, combine_keys(parent, :parent)]
+                  r[key] = [parent, combine_keys(parent)]
                 }
               else
                 (parents.is_a?(Array) ? parents : [parents])
                   .each_with_object({}) { |parent, r|
                   r[parent.combine_tuple_key(type)] = [
-                    parent, combine_keys(parent, :parent)
+                    parent, combine_keys(parent)
                   ]
                 }
               end
@@ -81,33 +81,28 @@ module ROM
             h[type] =
               if children.is_a?(Hash)
                 children.each_with_object({}) { |(key, child), r|
-                  r[key] = [child, combine_keys(relation, :children)]
+                  r[key] = [child, child.meta.fetch(:keys) { combine_keys(relation) }.invert]
                 }
               else
                 (children.is_a?(Array) ? children : [children])
                   .each_with_object({}) { |child, r|
                   r[child.combine_tuple_key(type)] = [
-                    child, combine_keys(relation, :children)
+                    child, child.meta.fetch(:keys) { combine_keys(relation) }.invert
                   ]
                 }
               end
           })
         end
 
-        # Infer join keys for a given relation and association type
+        # Infer join keys for a given relation
         #
         # @param [RelationProxy] relation
-        # @param [Symbol] type The type can be either :parent or :children
         #
         # @return [Hash<Symbol=>Symbol>]
         #
         # @api private
-        def combine_keys(relation, type)
-          if type == :parent
-            { relation.foreign_key => relation.primary_key }
-          else
-            { relation.primary_key => relation.foreign_key }
-          end
+        def combine_keys(relation)
+          { relation.foreign_key => relation.primary_key }
         end
 
         # Infer relation for combine operation

--- a/lib/rom/repository/relation_proxy/wrap.rb
+++ b/lib/rom/repository/relation_proxy/wrap.rb
@@ -38,7 +38,7 @@ module ROM
         def wrap_parent(options)
           wrap(
             options.each_with_object({}) { |(name, parent), h|
-              h[name] = [parent, combine_keys(parent, :children)]
+              h[name] = [parent, combine_keys(parent).invert]
             }
           )
         end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -48,4 +48,12 @@ RSpec.describe 'ROM repository' do
   it 'loads a wrapped relation' do
     expect(repo.tag_with_wrapped_task.first).to eql(tag_with_task)
   end
+
+  it 'loads a relation by an association with custom keys' do
+    expect(repo.accounts_for_users(repo.all_users)).to match_array([jane_account])
+  end
+
+  it 'loads a combine relation with many children and custom keys' do
+    expect(repo.users_with_accounts.to_a).to match_array([jane_with_accounts, joe_without_accounts])
+  end
 end

--- a/spec/shared/database.rb
+++ b/spec/shared/database.rb
@@ -7,7 +7,7 @@ RSpec.shared_context 'database' do
   before do
     conn.loggers << LOGGER
 
-    [:tags, :tasks, :users].each { |table| conn.drop_table?(table) }
+    [:tags, :tasks, :user_accounts, :users].each { |table| conn.drop_table?(table) }
 
     conn.create_table :users do
       primary_key :id
@@ -24,6 +24,12 @@ RSpec.shared_context 'database' do
       primary_key :id
       foreign_key :task_id, :tasks, null: false, on_delete: :cascade
       column :name, String
+    end
+
+    conn.create_table :user_accounts do
+      primary_key :account_id
+      column :account_no, String
+      foreign_key :owner_id, :users, null: false, on_delete: :cascade
     end
   end
 end

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -33,5 +33,17 @@ RSpec.shared_context 'relations' do
     end
 
     configuration.relation(:tags)
+
+    configuration.relation(:accounts) do
+      dataset :user_accounts
+
+      def name
+        :accounts
+      end
+
+      def for_users(users)
+        where(owner_id: users.map { |u| u[:id] })
+      end
+    end
   end
 end

--- a/spec/shared/repo.rb
+++ b/spec/shared/repo.rb
@@ -6,7 +6,7 @@ RSpec.shared_context('repo') do
 
   let(:repo_class) do
     Class.new(ROM::Repository[:users]) do
-      relations :tasks, :tags
+      relations :tasks, :tags, accounts: { owner_id: :id }
 
       def find_users(criteria)
         users.find(criteria)
@@ -54,6 +54,14 @@ RSpec.shared_context('repo') do
 
       def tag_with_wrapped_task
         tags.wrap_parent(task: tasks)
+      end
+
+      def users_with_accounts
+        aggregate(many: { all_accounts: accounts.for_users })
+      end
+
+      def accounts_for_users(users)
+        accounts.for_users(users)
       end
     end
   end

--- a/spec/shared/seeds.rb
+++ b/spec/shared/seeds.rb
@@ -7,5 +7,7 @@ RSpec.shared_context 'seeds' do
     task_id = conn[:tasks].insert user_id: jane_id, title: 'Jane Task'
 
     conn[:tags].insert task_id: task_id, name: 'red'
+
+    conn[:user_accounts].insert owner_id: jane_id, account_no: 'A-645'
   end
 end

--- a/spec/shared/structs.rb
+++ b/spec/shared/structs.rb
@@ -13,6 +13,10 @@ RSpec.shared_context 'structs' do
     repo.tags.mapper.model
   end
 
+  let(:account_struct) do
+    repo.accounts.mapper.model
+  end
+
   let(:tag_with_task_struct) do
     mapper_for(repo.tag_with_wrapped_task).model
   end
@@ -35,6 +39,10 @@ RSpec.shared_context 'structs' do
 
   let(:task_with_owner_struct) do
     mapper_for(repo.task_with_owner).model
+  end
+
+  let(:user_with_accounts_struct) do
+    mapper_for(repo.users_with_accounts).model
   end
 
   let(:jane) do
@@ -99,5 +107,17 @@ RSpec.shared_context 'structs' do
 
   let(:joe_task) do
     task_struct.new(id: 1, user_id: 2, title: 'Joe Task')
+  end
+
+  let(:jane_account) do
+    account_struct.new(account_id: 1, owner_id: 1, account_no: 'A-645')
+  end
+
+  let(:jane_with_accounts) do
+    user_with_accounts_struct.new(id: 1, name: 'Jane', all_accounts: [jane_account])
+  end
+
+  let(:joe_without_accounts) do
+    user_with_accounts_struct.new(id: 2, name: 'Joe', all_accounts: [])
   end
 end


### PR DESCRIPTION
In my current project I have custom primary and foreign keys. I kind of hacked previous version of the lib by passing custom LoadingProxy class. Now I think it is time to support custom keys as first class citizens. My concern is that DB design should be decoupled from the application code so ability to configure your new shiny lib/framework/whatever with an existing DB is quite important from my point of view.

Let me know if you're OK with the changes and I'll add some more test cases.
