### PR TITLE
[WIP] Add Changeset

### DIFF
--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -1,0 +1,19 @@
+module ROM
+  class Repository
+    class Changeset
+      attr_reader :relation
+
+      attr_reader :data
+
+      def initialize(relation, data)
+        @relation = relation
+        @data = data
+      end
+
+      def to_h
+        data
+      end
+      alias_method :to_hash, :to_h
+    end
+  end
+end

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -99,7 +99,7 @@ module ROM
 
           plugins.each { |plugin| klass.use(plugin) }
 
-          registry[name][type] = klass.build(relation, result: result)
+          registry[name][type] = klass.build(relation, result: result, input: Hash)
         end
       end
     end

--- a/lib/rom/repository/relation_proxy.rb
+++ b/lib/rom/repository/relation_proxy.rb
@@ -4,6 +4,8 @@ require 'rom/relation/materializable'
 require 'rom/repository/relation_proxy/combine'
 require 'rom/repository/relation_proxy/wrap'
 
+require 'rom/repository/changeset'
+
 module ROM
   class Repository
     # RelationProxy decorates a relation and automatically generate mappers that
@@ -39,6 +41,11 @@ module ROM
       # @api public
       def call(*args)
         ((combine? || composite?) ? relation : (relation >> mapper)).call(*args)
+      end
+
+      # @api private
+      def changeset(input)
+        Changeset.new(relation, input)
       end
 
       # Map this relation with other mappers too

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'Using changesets' do
+  subject(:repo) do
+    Class.new(ROM::Repository[:users]) { commands :create }.new(rom)
+  end
+
+  include_context 'database'
+  include_context 'relations'
+
+  before do
+    configuration.commands(:users) do
+      define(:create)
+    end
+  end
+
+  it 'returns a changeset for a given relation' do
+    command = repo.command(:create, repo.users)
+    changeset = repo.users.changeset(name: "Jane Doe")
+
+    result = command.(changeset)
+
+    expect(result.id).to_not be(nil)
+    expect(result.name).to eql("Jane Doe")
+  end
+end


### PR DESCRIPTION
### Summary

This adds a new concept called `Changeset` which is an object that encapsulates data that are going to be used to make changes in a datastore. It is a good place to add additional behaviors like checking if something actually changed, setting default values and dealing with custom coercions (delegated to dry-types schemas). We'll be able to use custom changeset types for specific commands too, configurable at the repository level.

A changeset implements required protocol for commands so it can be passed in to a command directly and it'll just work. When used with auto-commands inside repo, in simple cases, changesets will be used behind the scenes, but you can configure custom changeset types if you need additional behavior. We won't need inheritance here as the protocol is as simple as `#to_hash`, but in many cases you'll probably want to use a subclass of `Changeset` as it provides core behaviors that are useful, like schema-specific coercions.
### API ideas

``` ruby
# configuring default command behavior will use default changeset implementations
class UserRepo < ROM::Repository[:users]
  commands :create, :update
end

user_repo.create(name: "Jane")
user_repo.update(1, name: "Jane Doe")

# NEW STUFF: setting up custom changesets
class NewUserChangeset < ROM::Changeset
  def to_hash
    # do whatever you want
  end
end

class AdminUpdateChangeset < ROM::Changeset
  def to_hash
    # do whatever you want
  end
end

# we're gonna need a way to register those classes somehow
# then we can just point to its identifiers when setting up commands
class UserRepo < ROM::Repository[:users]
  commands create: :new_user, update: :admin_update
end

# works the same but uses custom changesets
user_repo.create(name: "Jane")
user_repo.update(1, name: "Jane Doe")

# NEW STUFF: accessing changesets and using the directly
changeset = user_repo.changeset(1, name: "Jane Doe")

# is there a diff?
changeset.diff? # true if something is going to change in the db

# gimme a data structure that will be persisted if there's a diff
changeset.to_hash

# commit this changeset
command = user_repo.command(:update, user_repo.users)

# just like dis
command.by_id(1).(changeset) # returns a struct constructed from the persisted tuple
```
### TODO
- [x] Add Changeset class
- [ ] Figure out a nice way for setting up dry-type hash schema for a given changeset
- [ ] Figure out an interface for committing a change
- [ ] Add extendible processing pipeline so that we can easily plug in things like setting up default values (ie timestamps)
- [ ] wire this up with auto-commands in Repo
