### PR TITLE
Changeset API

### DIFF
--- a/benchmarks/basic.rb
+++ b/benchmarks/basic.rb
@@ -5,12 +5,50 @@ benchmark('creating a user') do |x|
     user_repo.create(name: 'Jane', email: 'jane@doe.org', age: 21)
   end
 
+  x.report('rom-repository with a changeset') do
+    changeset = user_repo.changeset(name: 'Jane', email: 'jane@doe.org', age: 21)
+    user_repo.create(changeset)
+  end
+
   x.report('sequel') do
     Sequel::User.create(name: 'Jane', email: 'jane@doe.org', age: 21)
   end
 
   x.report('activerecord') do
     AR::User.create(name: 'Jane', email: 'jane@doe.org', age: 21)
+  end
+
+  x.compare!
+end
+
+benchmark('creating and updating a user') do |x|
+  x.report('rom-repository') do
+    user = user_repo.create(name: 'Jane', email: 'jane@doe.org', age: 21)
+
+    user_repo.update(user.id, name: 'Jane Doe')
+  end
+
+  x.report('rom-repository with a changeset') do
+    user = user_repo.create(name: 'Jane', email: 'jane@doe.org', age: 21)
+    changeset = user_repo.changeset(user.id, name: 'Jane Doe')
+
+    user_repo.update(user.id, changeset)
+  end
+
+  x.report('sequel') do
+    user = Sequel::User.create(name: 'Jane', email: 'jane@doe.org', age: 21)
+
+    updated_user = Sequel::User[user.id]
+    updated_user.name = 'Jane Doe'
+    updated_user.save
+  end
+
+  x.report('activerecord') do
+    user = AR::User.create(name: 'Jane', email: 'jane@doe.org', age: 21)
+
+    updated_user = AR::User.find(user.id)
+    updated_user.name = 'Jane Doe'
+    updated_user.save
   end
 
   x.compare!

--- a/benchmarks/setup.rb
+++ b/benchmarks/setup.rb
@@ -79,6 +79,10 @@ module Relations
       attribute :age, Types::Int
     end
 
+    def by_id(id)
+      where(id: id).limit(1)
+    end
+
     def by_name(name)
       where(name: name).limit(1)
     end
@@ -97,7 +101,7 @@ setup.register_relation(Relations::Users)
 setup.register_relation(Relations::Tasks)
 
 class UserRepo < ROM::Repository[:users]
-  commands :create
+  commands :create, update: :by_id
 
   def [](id)
     users.where(id: id).one!

--- a/bin/console
+++ b/bin/console
@@ -5,6 +5,15 @@ require "rom-repository"
 
 config = ROM::Configuration.new(:sql, 'postgres://localhost/rom_repository').use(:macros)
 
+config.relation(:books) do
+  schema(:books) do
+    attribute :id, ROM::SQL::Types::Serial
+    attribute :title, ROM::SQL::Types::String
+    attribute :created_at, ROM::SQL::Types::Time
+    attribute :updated_at, ROM::SQL::Types::Time
+  end
+end
+
 config.relation(:users) do
   def by_id(id)
     where(id: id)
@@ -33,7 +42,7 @@ config.relation(:tags)
 
 rom = ROM.container(config)
 
-repo = Class.new(ROM::Repository) { relations :users, :tasks, :tags }.new(rom)
+repo = Class.new(ROM::Repository) { relations :users, :tasks, :tags, :books }.new(rom)
 
 require "pry"
 binding.pry

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -8,6 +8,8 @@ require 'rom/repository/command_compiler'
 
 require 'rom/repository/root'
 
+require 'rom/repository/relation'
+
 module ROM
   # Abstract repository class to inherit from
   #

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -76,8 +76,8 @@ module ROM
     end
 
     # @api public
-    def changeset(rel_name, data)
-      relations[rel_name].changeset(data)
+    def changeset(rel_name, *args)
+      relations[rel_name].changeset(*args)
     end
 
     private

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -102,5 +102,10 @@ module ROM
 
       CommandCompiler[container, type, adapter, ast, use] >> mapper_instance
     end
+
+    # @api private
+    def map_tuple(relation, tuple)
+      relations[relation.name].mapper.([tuple]).first
+    end
   end
 end

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -75,6 +75,11 @@ module ROM
       end
     end
 
+    # @api public
+    def changeset(rel_name, data)
+      relations[rel_name].changeset(data)
+    end
+
     private
 
     def commands

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -52,6 +52,31 @@ module ROM
         pipe.call(data)
       end
       alias_method :to_hash, :to_h
+
+      def to_a
+        [to_h]
+      end
+      alias_method :to_ary, :to_a
+
+      private
+
+      def respond_to_missing?(meth, include_private = false)
+        super || data.respond_to?(meth)
+      end
+
+      def method_missing(meth, *args, &block)
+        if data.respond_to?(meth)
+          response = data.__send__(meth, *args, &block)
+
+          if response.is_a?(Hash)
+            self.class.new(relation, response, pipe)
+          else
+            response
+          end
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -1,81 +1,79 @@
 module ROM
-  class Repository
-    class Changeset
-      attr_reader :relation
+  class Changeset
+    attr_reader :relation
 
-      attr_reader :data
+    attr_reader :data
 
-      attr_reader :pipe
+    attr_reader :pipe
 
-      class Pipe
-        extend Transproc::Registry
+    class Pipe
+      extend Transproc::Registry
 
-        attr_reader :processor
+      attr_reader :processor
 
-        def self.add_timestamps(data)
-          now = Time.now
-          data.merge(created_at: now, updated_at: now)
-        end
-
-        def self.coerce(data, schema)
-          schema[data]
-        end
-
-        def initialize(processor)
-          @processor = processor
-        end
-
-        def >>(other)
-          self.class.new(processor >> other)
-        end
-
-        def call(data)
-          processor.call(data)
-        end
+      def self.add_timestamps(data)
+        now = Time.now
+        data.merge(created_at: now, updated_at: now)
       end
 
-      def self.default_pipe(relation)
-        Pipe.new(Pipe[:coerce, -> data { data }])
+      def self.coerce(data, schema)
+        schema[data]
       end
 
-      def initialize(relation, data, pipe = Changeset.default_pipe(relation))
-        @relation = relation
-        @data = data
-        @pipe = pipe
+      def initialize(processor)
+        @processor = processor
       end
 
-      def map(*steps)
-        self.class.new(relation, data, steps.reduce(pipe) { |a, e| a >> pipe.class[e] })
+      def >>(other)
+        self.class.new(processor >> other)
       end
 
-      def to_h
-        pipe.call(data)
+      def call(data)
+        processor.call(data)
       end
-      alias_method :to_hash, :to_h
+    end
 
-      def to_a
-        [to_h]
-      end
-      alias_method :to_ary, :to_a
+    def self.default_pipe(relation)
+      Pipe.new(Pipe[:coerce, -> data { data }])
+    end
 
-      private
+    def initialize(relation, data, pipe = Changeset.default_pipe(relation))
+      @relation = relation
+      @data = data
+      @pipe = pipe
+    end
 
-      def respond_to_missing?(meth, include_private = false)
-        super || data.respond_to?(meth)
-      end
+    def map(*steps)
+      self.class.new(relation, data, steps.reduce(pipe) { |a, e| a >> pipe.class[e] })
+    end
 
-      def method_missing(meth, *args, &block)
-        if data.respond_to?(meth)
-          response = data.__send__(meth, *args, &block)
+    def to_h
+      pipe.call(data)
+    end
+    alias_method :to_hash, :to_h
 
-          if response.is_a?(Hash)
-            self.class.new(relation, response, pipe)
-          else
-            response
-          end
+    def to_a
+      [to_h]
+    end
+    alias_method :to_ary, :to_a
+
+    private
+
+    def respond_to_missing?(meth, include_private = false)
+      super || data.respond_to?(meth)
+    end
+
+    def method_missing(meth, *args, &block)
+      if data.respond_to?(meth)
+        response = data.__send__(meth, *args, &block)
+
+        if response.is_a?(Hash)
+          self.class.new(relation, response, pipe)
         else
-          super
+          response
         end
+      else
+        super
       end
     end
   end

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -57,6 +57,17 @@ module ROM
     end
     alias_method :to_ary, :to_a
 
+    def diff?
+      ! diff.empty?
+    end
+
+    def diff
+      data_ary = data.to_a
+      original = relation.fetch(*data.values_at(relation.primary_key)).to_a
+
+      Hash[data_ary - (data_ary & original)]
+    end
+
     private
 
     def respond_to_missing?(meth, include_private = false)

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -35,7 +35,7 @@ module ROM
       end
 
       def self.default_pipe(relation)
-        Pipe.new(Pipe[:coerce, ROM::Types::Hash.schema(relation.schema.attributes)])
+        Pipe.new(Pipe[:coerce, -> data { data }])
       end
 
       def initialize(relation, data, pipe = Changeset.default_pipe(relation))

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -38,6 +38,11 @@ module ROM
         false
       end
 
+      def to_h
+        pipe.call(diff)
+      end
+      alias_method :to_hash, :to_h
+
       def diff?
         ! diff.empty?
       end
@@ -58,6 +63,10 @@ module ROM
       def self.add_timestamps(data)
         now = Time.now
         data.merge(created_at: now, updated_at: now)
+      end
+
+      def self.touch(data)
+        data.merge(updated_at: Time.now)
       end
 
       def self.coerce(data, schema)

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -58,6 +58,10 @@ module ROM
         false
       end
 
+      def original
+        @original ||= relation.fetch(primary_key)
+      end
+
       def to_h
         pipe.call(diff)
       end
@@ -67,11 +71,18 @@ module ROM
         ! diff.empty?
       end
 
-      def diff
-        data_ary = data.to_a
-        original = relation.fetch(primary_key).to_a
+      def clean?
+        diff.empty?
+      end
 
-        Hash[data_ary - (data_ary & original)]
+      def diff
+        @diff ||=
+          begin
+            new_tuple = data.to_a
+            ori_tuple = original.to_a
+
+            Hash[new_tuple - (new_tuple & ori_tuple)]
+          end
       end
     end
 

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -23,50 +23,79 @@ module ROM
   class Changeset
     include Options
 
+    # @!attribute [r] pipe
+    #   @return [Changeset::Pipe] data transformation pipe
     option :pipe, reader: true, accept: [Proc, Pipe], default: -> changeset {
       changeset.class.default_pipe
     }
 
+    # @!attribute [r] relation
+    #   @return [Relation] The changeset relation
     attr_reader :relation
 
+    # @!attribute [r] data
+    #   @return [Hash] The relation data
     attr_reader :data
 
-    attr_reader :pipe
-
+    # Build default pipe object
+    #
+    # This can be overridden in a custom changeset subclass
+    #
+    # @return [Pipe]
     def self.default_pipe
       Pipe.new
     end
 
+    # @api private
     def initialize(relation, data, options = EMPTY_HASH)
       @relation = relation
       @data = data
       super
     end
 
+    # Pipe changeset's data using custom steps define on the pipe
+    #
+    # This accepts a splatted list of step names that correspond to pipe's
+    # singleton mapping functions
+    #
+    # @return [Changeset]
+    #
+    # @api public
     def map(*steps)
       with(pipe: steps.reduce(pipe) { |a, e| a >> pipe.class[e] })
     end
 
+    # Coerce changeset to a hash
+    #
+    # This will send the data through the pipe
+    #
+    # @return [Hash]
+    #
+    # @api public
     def to_h
       pipe.call(data)
     end
     alias_method :to_hash, :to_h
 
-    def to_a
-      [to_h]
-    end
-    alias_method :to_ary, :to_a
-
+    # Return a new changeset with updated options
+    #
+    # @param [Hash] new_options The new options
+    #
+    # @return [Changeset]
+    #
+    # @api private
     def with(new_options)
       self.class.new(relation, data, options.merge(new_options))
     end
 
     private
 
+    # @api private
     def respond_to_missing?(meth, include_private = false)
       super || data.respond_to?(meth)
     end
 
+    # @api private
     def method_missing(meth, *args, &block)
       if data.respond_to?(meth)
         response = data.__send__(meth, *args, &block)

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -1,0 +1,19 @@
+module ROM
+  class Repository
+    class Changeset
+      attr_reader :relation
+
+      attr_reader :data
+
+      def initialize(relation, data)
+        @relation = relation
+        @data = data
+      end
+
+      def to_h
+        data
+      end
+      alias_method :to_hash, :to_h
+    end
+  end
+end

--- a/lib/rom/repository/changeset/create.rb
+++ b/lib/rom/repository/changeset/create.rb
@@ -1,10 +1,23 @@
 module ROM
   class Changeset
+    # Changeset specialization for create commands
+    #
+    # @api public
     class Create < Changeset
+      # Return false
+      #
+      # @return [FalseClass]
+      #
+      # @api public
       def update?
         false
       end
 
+      # Return true
+      #
+      # @return [TrueClass]
+      #
+      # @api public
       def create?
         true
       end

--- a/lib/rom/repository/changeset/create.rb
+++ b/lib/rom/repository/changeset/create.rb
@@ -1,0 +1,13 @@
+module ROM
+  class Changeset
+    class Create < Changeset
+      def update?
+        false
+      end
+
+      def create?
+        true
+      end
+    end
+  end
+end

--- a/lib/rom/repository/changeset/pipe.rb
+++ b/lib/rom/repository/changeset/pipe.rb
@@ -1,0 +1,40 @@
+require 'transproc/registry'
+
+module ROM
+  class Changeset
+    class Pipe
+      extend Transproc::Registry
+
+      attr_reader :processor
+
+      def self.add_timestamps(data)
+        now = Time.now
+        data.merge(created_at: now, updated_at: now)
+      end
+
+      def self.touch(data)
+        data.merge(updated_at: Time.now)
+      end
+
+      def initialize(processor = nil)
+        @processor = processor
+      end
+
+      def >>(other)
+        if processor
+          self.class.new(processor >> other)
+        else
+          self.class.new(other)
+        end
+      end
+
+      def call(data)
+        if processor
+          processor.call(data)
+        else
+          data
+        end
+      end
+    end
+  end
+end

--- a/lib/rom/repository/class_interface.rb
+++ b/lib/rom/repository/class_interface.rb
@@ -86,9 +86,15 @@ module ROM
           define_method(meth_name) do |*args|
             view_args, *input = args
 
-            command(type => self.class.root, **opts)
-              .public_send(view_name, *view_args)
-              .call(*input)
+            changeset = input.first
+
+            if changeset.is_a?(Changeset) && changeset.clean?
+              map_tuple(changeset.relation, changeset.original)
+            else
+              command(type => self.class.root, **opts)
+                .public_send(view_name, *view_args)
+                .call(*input)
+            end
           end
         end
       end

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -153,9 +153,7 @@ module ROM
 
           finalize_command_class(klass, relation)
 
-          registry[rel_name][type] = klass.build(
-            relation, input: relation.schema_processor
-          )
+          registry[rel_name][type] = klass.build(relation, input: relation.schema_hash)
         end
       end
 

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -177,7 +177,7 @@ module ROM
           klass.associates(assoc.name)
         end or (
           keys = meta[:keys].invert.to_a.flatten
-          klass.associates(parent_relation, key: keys)
+          klass.associates(parent_relation, key: keys, input: Hash)
         )
       end
 

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -153,7 +153,7 @@ module ROM
 
           finalize_command_class(klass, relation)
 
-          registry[name][type] = klass.build(
+          registry[rel_name][type] = klass.build(
             relation, input: relation.schema_processor
           )
         end
@@ -179,7 +179,7 @@ module ROM
           klass.associates(assoc.name)
         end or (
           keys = meta[:keys].invert.to_a.flatten
-          klass.associates(parent_relation, key: keys, input: Hash)
+          klass.associates(parent_relation, key: keys)
         )
       end
 

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -153,7 +153,15 @@ module ROM
 
           finalize_command_class(klass, relation)
 
-          registry[rel_name][type] = klass.build(relation)
+          # TODO: this should be baked into rom core probably
+          input =
+            if relation.schema?
+              -> data { Types::Hash.schema(relation.schema.attributes)[Hash[data]] }
+            else
+              Hash
+            end
+
+          registry[rel_name][type] = klass.build(relation, input: input)
         end
       end
 

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -153,15 +153,9 @@ module ROM
 
           finalize_command_class(klass, relation)
 
-          # TODO: this should be baked into rom core probably
-          input =
-            if relation.schema?
-              -> data { Types::Hash.schema(relation.schema.attributes)[Hash[data]] }
-            else
-              Hash
-            end
-
-          registry[rel_name][type] = klass.build(relation, input: input)
+          registry[name][type] = klass.build(
+            relation, input: relation.schema_processor
+          )
         end
       end
 

--- a/lib/rom/repository/relation.rb
+++ b/lib/rom/repository/relation.rb
@@ -6,7 +6,7 @@ module ROM
   class Relation
     # @api private
     def changeset(input)
-      Repository::Changeset.new(self, input)
+      Changeset.new(self, input)
     end
 
     # @api private

--- a/lib/rom/repository/relation.rb
+++ b/lib/rom/repository/relation.rb
@@ -6,7 +6,7 @@ module ROM
   class Relation
     # @api private
     def changeset(input)
-      Changeset.new(self, input)
+      ROM.Changeset(self, input)
     end
 
     # @api private

--- a/lib/rom/repository/relation.rb
+++ b/lib/rom/repository/relation.rb
@@ -1,0 +1,28 @@
+require 'rom/repository/changeset'
+require 'rom/types'
+
+module ROM
+  # TODO: these APIs are candidates for inclusion into rom core
+  class Relation
+    # @api private
+    def changeset(input)
+      Repository::Changeset.new(self, input)
+    end
+
+    # @api private
+    # TODO: might be worth considering a schema hash which does hash conversion
+    #       by default so that we can avoid creating a proc here
+    def schema_processor
+      if schema?
+        -> data { schema_hash[Hash[data]] }
+      else
+        Hash
+      end
+    end
+
+    # @api private
+    def schema_hash
+      Types::Hash.schema(schema.attributes)
+    end
+  end
+end

--- a/lib/rom/repository/relation.rb
+++ b/lib/rom/repository/relation.rb
@@ -10,8 +10,8 @@ module ROM
     end
 
     # @api public
-    def changeset(input)
-      ROM.Changeset(self, input)
+    def changeset(*args)
+      ROM.Changeset(self, *args)
     end
 
     # @api private

--- a/lib/rom/repository/relation.rb
+++ b/lib/rom/repository/relation.rb
@@ -5,6 +5,11 @@ module ROM
   # TODO: these APIs are candidates for inclusion into rom core
   class Relation
     # @api public
+    def fetch(pk)
+      where(primary_key => pk).one!
+    end
+
+    # @api public
     def changeset(input)
       ROM.Changeset(self, input)
     end

--- a/lib/rom/repository/relation.rb
+++ b/lib/rom/repository/relation.rb
@@ -4,25 +4,18 @@ require 'rom/types'
 module ROM
   # TODO: these APIs are candidates for inclusion into rom core
   class Relation
-    # @api private
+    # @api public
     def changeset(input)
       ROM.Changeset(self, input)
     end
 
     # @api private
-    # TODO: might be worth considering a schema hash which does hash conversion
-    #       by default so that we can avoid creating a proc here
-    def schema_processor
+    def schema_hash
       if schema?
-        -> data { schema_hash[Hash[data]] }
+        Types::Coercible::Hash.schema(schema.attributes)
       else
         Hash
       end
-    end
-
-    # @api private
-    def schema_hash
-      Types::Hash.schema(schema.attributes)
     end
   end
 end

--- a/lib/rom/repository/relation_proxy.rb
+++ b/lib/rom/repository/relation_proxy.rb
@@ -4,8 +4,6 @@ require 'rom/relation/materializable'
 require 'rom/repository/relation_proxy/combine'
 require 'rom/repository/relation_proxy/wrap'
 
-require 'rom/repository/changeset'
-
 module ROM
   class Repository
     # RelationProxy decorates a relation and automatically generate mappers that

--- a/lib/rom/repository/relation_proxy.rb
+++ b/lib/rom/repository/relation_proxy.rb
@@ -4,6 +4,8 @@ require 'rom/relation/materializable'
 require 'rom/repository/relation_proxy/combine'
 require 'rom/repository/relation_proxy/wrap'
 
+require 'rom/repository/changeset'
+
 module ROM
   class Repository
     # RelationProxy decorates a relation and automatically generate mappers that
@@ -42,6 +44,11 @@ module ROM
       # @api public
       def call(*args)
         ((combine? || composite?) ? relation : (relation >> mapper)).call(*args)
+      end
+
+      # @api private
+      def changeset(input)
+        Changeset.new(relation, input)
       end
 
       # Map this relation with other mappers too

--- a/lib/rom/repository/relation_proxy.rb
+++ b/lib/rom/repository/relation_proxy.rb
@@ -46,11 +46,6 @@ module ROM
         ((combine? || composite?) ? relation : (relation >> mapper)).call(*args)
       end
 
-      # @api private
-      def changeset(input)
-        Changeset.new(relation, input)
-      end
-
       # Map this relation with other mappers too
       #
       # @api public

--- a/lib/rom/repository/root.rb
+++ b/lib/rom/repository/root.rb
@@ -30,10 +30,10 @@ module ROM
 
       # @api public
       def changeset(*args)
-        if args.size == 2
+        if args.first.is_a?(Symbol) && relations.key?(args.first)
           super
         else
-          super(self.class.root, args.first)
+          super(self.class.root, *args)
         end
       end
     end

--- a/lib/rom/repository/root.rb
+++ b/lib/rom/repository/root.rb
@@ -27,6 +27,15 @@ module ROM
           root.combine(*args)
         end
       end
+
+      # @api public
+      def changeset(*args)
+        if args.size == 2
+          super
+        else
+          super(self.class.root, args.first)
+        end
+      end
     end
   end
 end

--- a/rom-repository.gemspec
+++ b/rom-repository.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'rom', '~> 2.0'
-  gem.add_runtime_dependency 'rom-support', '~> 1.0.0'
-  gem.add_runtime_dependency 'rom-mapper', '~> 0.3.0'
+  gem.add_runtime_dependency 'rom-support', '~> 1.0'
+  gem.add_runtime_dependency 'rom-mapper', '~> 0.3'
   gem.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
   gem.add_development_dependency 'rake', '~> 11.2'

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Using changesets' do
   subject(:repo) do
-    Class.new(ROM::Repository[:users]) { commands :create }.new(rom)
+    Class.new(ROM::Repository[:users]) { relations :books; commands :create }.new(rom)
   end
 
   include_context 'database'
@@ -13,12 +13,22 @@ RSpec.describe 'Using changesets' do
   end
 
   it 'returns a changeset for a given relation' do
-    command = repo.command(:create, repo.users)
     changeset = repo.users.changeset(name: "Jane Doe")
-
+    command = repo.command(:create, repo.users)
     result = command.(changeset)
 
     expect(result.id).to_not be(nil)
     expect(result.name).to eql("Jane Doe")
+  end
+
+  it 'data pipe' do
+    changeset = repo.books.changeset(title: "rom-rb is awesome").map(:add_timestamps)
+    command = repo.command(:create, repo.books)
+    result = command.(changeset)
+
+    expect(result.id).to_not be(nil)
+    expect(result.title).to eql("rom-rb is awesome")
+    expect(result.created_at).to be_instance_of(Time)
+    expect(result.updated_at).to be_instance_of(Time)
   end
 end

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Using changesets' do
   it 'can be passed to a command graph' do
     changeset = repo
       .aggregate(:posts)
-      .changeset(name: "Jane Doe", posts: [{ title: "Just Do It" }])
+      .changeset(name: "Jane Doe", posts: [{ title: "Just Do It", alien: "or sutin" }])
 
     command = repo.command(:create, repo.aggregate(:posts))
     result = command.(changeset)

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Using changesets' do
   end
 
   it 'can be passed to a command' do
-    changeset = repo.users.changeset(name: "Jane Doe")
+    changeset = repo.changeset(name: "Jane Doe")
     command = repo.command(:create, repo.users)
     result = command.(changeset)
 
@@ -25,9 +25,9 @@ RSpec.describe 'Using changesets' do
   end
 
   it 'can be passed to a command graph' do
-    changeset = repo
-      .aggregate(:posts)
-      .changeset(name: "Jane Doe", posts: [{ title: "Just Do It", alien: "or sutin" }])
+    changeset = repo.changeset(
+      name: "Jane Doe", posts: [{ title: "Just Do It", alien: "or sutin" }]
+    )
 
     command = repo.command(:create, repo.aggregate(:posts))
     result = command.(changeset)
@@ -39,7 +39,7 @@ RSpec.describe 'Using changesets' do
   end
 
   it 'data pipe' do
-    changeset = repo.books.changeset(title: "rom-rb is awesome").map(:add_timestamps)
+    changeset = repo.changeset(:books, title: "rom-rb is awesome").map(:add_timestamps)
     command = repo.command(:create, repo.books)
     result = command.(changeset)
 

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -67,5 +67,20 @@ RSpec.describe 'Using changesets' do
       expect(result.title).to eql('rom-rb is awesome for real')
       expect(result.updated_at).to be_instance_of(Time)
     end
+
+    it 'skips update execution with no diff' do
+      book = repo.create(title: 'rom-rb is awesome')
+
+      changeset = repo
+        .changeset(book.id, title: 'rom-rb is awesome')
+
+      expect(changeset).to_not be_diff
+
+      result = repo.update(book.id, changeset)
+
+      expect(result.id).to be(book.id)
+      expect(result.title).to eql('rom-rb is awesome')
+      expect(result.updated_at).to be(nil)
+    end
   end
 end

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -9,43 +9,45 @@ RSpec.describe 'Using changesets' do
   include_context 'database'
   include_context 'relations'
 
-  before do
-    configuration.commands(:users) do
-      define(:create)
+  describe 'Create' do
+    before do
+      configuration.commands(:users) do
+        define(:create)
+      end
     end
-  end
 
-  it 'can be passed to a command' do
-    changeset = repo.changeset(name: "Jane Doe")
-    command = repo.command(:create, repo.users)
-    result = command.(changeset)
+    it 'can be passed to a command' do
+      changeset = repo.changeset(name: "Jane Doe")
+      command = repo.command(:create, repo.users)
+      result = command.(changeset)
 
-    expect(result.id).to_not be(nil)
-    expect(result.name).to eql("Jane Doe")
-  end
+      expect(result.id).to_not be(nil)
+      expect(result.name).to eql("Jane Doe")
+    end
 
-  it 'can be passed to a command graph' do
-    changeset = repo.changeset(
-      name: "Jane Doe", posts: [{ title: "Just Do It", alien: "or sutin" }]
-    )
+    it 'can be passed to a command graph' do
+      changeset = repo.changeset(
+        name: "Jane Doe", posts: [{ title: "Just Do It", alien: "or sutin" }]
+      )
 
-    command = repo.command(:create, repo.aggregate(:posts))
-    result = command.(changeset)
+      command = repo.command(:create, repo.aggregate(:posts))
+      result = command.(changeset)
 
-    expect(result.id).to_not be(nil)
-    expect(result.name).to eql("Jane Doe")
-    expect(result.posts.size).to be(1)
-    expect(result.posts[0].title).to eql("Just Do It")
-  end
+      expect(result.id).to_not be(nil)
+      expect(result.name).to eql("Jane Doe")
+      expect(result.posts.size).to be(1)
+      expect(result.posts[0].title).to eql("Just Do It")
+    end
 
-  it 'data pipe' do
-    changeset = repo.changeset(:books, title: "rom-rb is awesome").map(:add_timestamps)
-    command = repo.command(:create, repo.books)
-    result = command.(changeset)
+    it 'preprocesses data using changeset pipes' do
+      changeset = repo.changeset(:books, title: "rom-rb is awesome").map(:add_timestamps)
+      command = repo.command(:create, repo.books)
+      result = command.(changeset)
 
-    expect(result.id).to_not be(nil)
-    expect(result.title).to eql("rom-rb is awesome")
-    expect(result.created_at).to be_instance_of(Time)
-    expect(result.updated_at).to be_instance_of(Time)
+      expect(result.id).to_not be(nil)
+      expect(result.title).to eql("rom-rb is awesome")
+      expect(result.created_at).to be_instance_of(Time)
+      expect(result.updated_at).to be_instance_of(Time)
+    end
   end
 end

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Using changesets' do
       book = repo.create(title: 'rom-rb is awesome')
 
       changeset = repo
-        .changeset(id: book.id, title: 'rom-rb is awesome for real')
+        .changeset(book.id, title: 'rom-rb is awesome for real')
         .map(:touch)
 
       expect(changeset.diff).to eql(title: 'rom-rb is awesome for real')

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'Using changesets' do
+  subject(:repo) do
+    Class.new(ROM::Repository[:users]) { commands :create }.new(rom)
+  end
+
+  include_context 'database'
+  include_context 'relations'
+
+  before do
+    configuration.commands(:users) do
+      define(:create)
+    end
+  end
+
+  it 'returns a changeset for a given relation' do
+    command = repo.command(:create, repo.users)
+    changeset = repo.users.changeset(name: "Jane Doe")
+
+    result = command.(changeset)
+
+    expect(result.id).to_not be(nil)
+    expect(result.name).to eql("Jane Doe")
+  end
+end

--- a/spec/shared/database.rb
+++ b/spec/shared/database.rb
@@ -13,8 +13,15 @@ RSpec.shared_context 'database' do
   before do
     conn.loggers << LOGGER
 
-    [:tags, :tasks, :posts, :users, :posts_labels, :labels,
+    [:tags, :tasks, :posts, :users, :posts_labels, :labels, :books,
      :reactions, :messages].each { |table| conn.drop_table?(table) }
+
+    conn.create_table :books do
+      primary_key :id
+      column :title, String
+      column :created_at, Time
+      column :updated_at, Time
+    end
 
     conn.create_table :users do
       primary_key :id

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -3,8 +3,18 @@ RSpec.shared_context 'relations' do
   let(:tasks) { rom.relation(:tasks) }
   let(:tags) { rom.relation(:tags) }
   let(:posts) { rom.relation(:posts) }
+  let(:books) { rom.relation(:books) }
 
   before do
+    configuration.relation(:books) do
+      schema(:books) do
+        attribute :id, ROM::SQL::Types::Serial
+        attribute :title, ROM::SQL::Types::String
+        attribute :created_at, ROM::SQL::Types::Time
+        attribute :updated_at, ROM::SQL::Types::Time
+      end
+    end
+
     configuration.relation(:users) do
       schema(:users) do
         attribute :id, ROM::SQL::Types::Serial

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -13,6 +13,10 @@ RSpec.shared_context 'relations' do
         attribute :created_at, ROM::SQL::Types::Time
         attribute :updated_at, ROM::SQL::Types::Time
       end
+
+      def by_id(id)
+        where(id: id)
+      end
     end
 
     configuration.relation(:users) do

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe ROM::Changeset do
-  subject(:changeset) { ROM::Changeset.new(relation, data) }
-
   let(:jane) { { id: 2, name: "Jane" } }
   let(:relation) { double(ROM::Relation, primary_key: :id) }
+
+  describe 'builder function' do
+    it 'returns a create changeset for new data' do
+      expect(ROM.Changeset(relation, name: "Jane")).to be_create
+    end
+
+    it 'returns an update changeset for persisted data' do
+      expect(ROM.Changeset(relation, jane)).to be_update
+    end
+  end
 
   describe '#diff' do
     it 'returns a hash with changes' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset.new(relation, id: 2, name: "Jane Doe")
+      changeset = ROM::Changeset(relation, id: 2, name: "Jane Doe")
 
       expect(changeset.diff).to eql(name: "Jane Doe")
     end
@@ -18,7 +26,7 @@ RSpec.describe ROM::Changeset do
     it 'returns true when data differs from the original tuple' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset.new(relation, id: 2, name: "Jane Doe")
+      changeset = ROM::Changeset(relation, id: 2, name: "Jane Doe")
 
       expect(changeset).to be_diff
     end
@@ -26,7 +34,7 @@ RSpec.describe ROM::Changeset do
     it 'returns false when data are equal to the original tuple' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset.new(relation, id: 2, name: "Jane")
+      changeset = ROM::Changeset(relation, id: 2, name: "Jane")
 
       expect(changeset).to_not be_diff
     end

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe ROM::Changeset do
+  subject(:changeset) { ROM::Changeset.new(relation, data) }
+
+  let(:jane) { { id: 2, name: "Jane" } }
+  let(:relation) { double(ROM::Relation, primary_key: :id) }
+
+  describe '#diff' do
+    it 'returns a hash with changes' do
+      expect(relation).to receive(:fetch).with(2).and_return(jane)
+
+      changeset = ROM::Changeset.new(relation, id: 2, name: "Jane Doe")
+
+      expect(changeset.diff).to eql(name: "Jane Doe")
+    end
+  end
+
+  describe '#diff?' do
+    it 'returns true when data differs from the original tuple' do
+      expect(relation).to receive(:fetch).with(2).and_return(jane)
+
+      changeset = ROM::Changeset.new(relation, id: 2, name: "Jane Doe")
+
+      expect(changeset).to be_diff
+    end
+
+    it 'returns false when data are equal to the original tuple' do
+      expect(relation).to receive(:fetch).with(2).and_return(jane)
+
+      changeset = ROM::Changeset.new(relation, id: 2, name: "Jane")
+
+      expect(changeset).to_not be_diff
+    end
+  end
+end

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ROM::Changeset do
     end
 
     it 'returns an update changeset for persisted data' do
-      expect(ROM.Changeset(relation, jane)).to be_update
+      expect(ROM.Changeset(relation, 2, jane)).to be_update
     end
   end
 
@@ -16,7 +16,7 @@ RSpec.describe ROM::Changeset do
     it 'returns a hash with changes' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset(relation, id: 2, name: "Jane Doe")
+      changeset = ROM::Changeset(relation, 2, name: "Jane Doe")
 
       expect(changeset.diff).to eql(name: "Jane Doe")
     end
@@ -26,7 +26,7 @@ RSpec.describe ROM::Changeset do
     it 'returns true when data differs from the original tuple' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset(relation, id: 2, name: "Jane Doe")
+      changeset = ROM::Changeset(relation, 2, name: "Jane Doe")
 
       expect(changeset).to be_diff
     end
@@ -34,7 +34,7 @@ RSpec.describe ROM::Changeset do
     it 'returns false when data are equal to the original tuple' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset(relation, id: 2, name: "Jane")
+      changeset = ROM::Changeset(relation, 2, name: "Jane")
 
       expect(changeset).to_not be_diff
     end

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe ROM::Changeset do
     it 'returns an update changeset for persisted data' do
       expect(ROM.Changeset(relation, 2, jane)).to be_update
     end
+
+    it 'raises ArgumentError when invalid args are passed' do
+      expect { ROM.Changeset(1, 2, 3, 4) }.to raise_error(
+        ArgumentError, 'ROM.Changeset accepts 2 or 3 arguments'
+      )
+    end
   end
 
   describe '#diff' do

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -39,4 +39,30 @@ RSpec.describe ROM::Changeset do
       expect(changeset).to_not be_diff
     end
   end
+
+  describe 'quacks like a hash' do
+    subject(:changeset) { ROM::Changeset.new(relation, data) }
+
+    let(:data) { instance_double(Hash) }
+
+    it 'delegates to its data hash' do
+      expect(data).to receive(:[]).with(:name).and_return('Jane')
+
+      expect(changeset[:name]).to eql('Jane')
+    end
+
+    it 'maintains its own type' do
+      expect(data).to receive(:merge).with(foo: 'bar').and_return(foo: 'bar')
+
+      new_changeset = changeset.merge(foo: 'bar')
+
+      expect(new_changeset).to be_instance_of(ROM::Changeset)
+      expect(new_changeset.options).to eql(changeset.options)
+      expect(new_changeset.to_h).to eql(foo: 'bar')
+    end
+
+    it 'raises NoMethodError when an unknown message was sent' do
+      expect { changeset.not_here }.to raise_error(NoMethodError, /not_here/)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

This adds a new concept called `Changeset` which is an object that encapsulates data that are going to be used to make changes in a datastore. It is a good place to add additional behaviors like checking if something actually changed, setting default values and dealing with custom coercions (delegated to dry-types schemas). We'll be able to use custom changeset types for specific commands too, configurable at the repository level.

A changeset implements required protocol for commands so it can be passed in to a command directly and it'll just work. When used with auto-commands inside repo, in simple cases, changesets will be used behind the scenes, but you can configure custom changeset types if you need additional behavior. We won't need inheritance here as the protocol is as simple as `#to_hash`, but in many cases you'll probably want to use a subclass of `Changeset` as it provides core behaviors that are useful, like schema-specific coercions.
### API ideas

``` ruby
# configuring default command behavior will use default changeset implementations
class UserRepo < ROM::Repository[:users]
  commands :create, :update
end

user_repo.create(name: "Jane")
user_repo.update(1, name: "Jane Doe")

# NEW STUFF: setting up custom changesets
class NewUserChangeset < ROM::Changeset
  def to_hash
    # do whatever you want
  end
end

class AdminUpdateChangeset < ROM::Changeset
  def to_hash
    # do whatever you want
  end
end

# we're gonna need a way to register those classes somehow
# then we can just point to its identifiers when setting up commands
class UserRepo < ROM::Repository[:users]
  commands create: :new_user, update: :admin_update
end

# works the same but uses custom changesets
user_repo.create(name: "Jane")
user_repo.update(1, name: "Jane Doe")

# NEW STUFF: accessing changesets and using the directly
changeset = user_repo.changeset(1, name: "Jane Doe")

# is there a diff?
changeset.diff? # true if something is going to change in the db

# gimme a data structure that will be persisted if there's a diff
changeset.to_hash

# commit this changeset
command = user_repo.command(:update, user_repo.users)

# just like dis
command.by_id(1).(changeset) # returns a struct constructed from the persisted tuple
```
### TODO
- [x] Add Changeset class
- [x] Figure out a nice way for setting up dry-type hash schema for a given changeset
- [x] Add extendible processing pipeline so that we can easily plug in things like setting up default values (ie timestamps)
- [x] Add `diff?` and `diff`
- [ ] Add a way for figuring out how to restrict an update command based on PK info in schema
- [ ] Figure out an interface for committing a change
- [ ] wire this up with auto-commands in Repo
