### PR TITLE
Manually create module for ROM::Struct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development do
 end
 
 group :test do
-  gem 'anima', '~> 0.2.0'
+  gem 'thread_safe'
   gem 'rspec'
   gem 'byebug', platforms: :mri
   gem 'pg', platforms: [:mri, :rbx]

--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -1,5 +1,3 @@
-require 'anima'
-
 require 'rom/support/class_builder'
 
 module ROM

--- a/rom-repository.gemspec
+++ b/rom-repository.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'anima', '~> 0.2', '>= 0.2'
   gem.add_runtime_dependency 'rom', '~> 2.0'
   gem.add_runtime_dependency 'rom-support', '~> 1.0.0'
   gem.add_runtime_dependency 'rom-mapper', '~> 0.3.0'

--- a/spec/unit/relation_proxy_spec.rb
+++ b/spec/unit/relation_proxy_spec.rb
@@ -55,7 +55,13 @@ RSpec.describe 'loading proxy' do
     end
 
     context 'setting custom model type' do
-      let(:user_type) { Class.new { include Anima.new(:id, :name) } }
+      let(:user_type) do
+        Class.new(Dry::Types::Struct) do
+          attribute :id, Dry::Types['strict.int']
+          attribute :name, Dry::Types['strict.string']
+        end
+      end
+
       let(:custom_users) { users.as(user_type) }
 
       it 'instantiates custom model' do


### PR DESCRIPTION
This drops anima dependency with a bunch of other gems. We're still depending on thread_safe gem in tests though because ROM::Memory::Storage requires it. I'll have a look if we can update it with concurrent-ruby gem, I'm pretty sure it'll be easy.
