### PR TITLE
Support arbitrary dataset names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'inflecto'
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
 
 gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
-gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
+gem 'rom-support', github: 'rom-rb/rom-support', branch: 'call-to_sym'
 
 group :development, :test do
   gem 'rom-sql', github: 'rom-rb/rom-sql', branch: 'use-qualified-combination-keys'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gemspec
 gem 'inflecto'
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
 
-gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
-gem 'rom-support', github: 'rom-rb/rom-support', branch: 'call-to_sym'
+gem 'rom', github: 'rom-rb/rom', branch: 'master'
+gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
 
 group :development, :test do
-  gem 'rom-sql', github: 'rom-rb/rom-sql', branch: 'use-qualified-combination-keys'
+  gem 'rom-sql', github: 'rom-rb/rom-sql', branch: 'master'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gemspec
 gem 'inflecto'
 gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
 
-gem 'rom', github: 'rom-rb/rom', branch: 'master'
+gem 'rom', github: 'rom-rb/rom', branch: 'add-explicit-relation-name'
 gem 'rom-support', github: 'rom-rb/rom-support', branch: 'master'
 
 group :development, :test do
-  gem 'rom-sql', github: 'rom-rb/rom-sql', branch: 'master'
+  gem 'rom-sql', github: 'rom-rb/rom-sql', branch: 'use-qualified-combination-keys'
 end
 
 group :development do

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -85,10 +85,10 @@ module ROM
       relation = name.is_a?(Symbol) ? relations[name] : name
 
       ast = relation.to_ast
-      adapter = relations[relation.name].adapter
+      adapter = relations[relation.name.relation].adapter
 
       if mapper
-        mapper_instance = container.mappers[relation.name][mapper]
+        mapper_instance = container.mappers[relation.name.relation][mapper]
       else
         mapper_instance = mappers[ast]
       end

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -52,17 +52,16 @@ module ROM
 
       def visit_relation(node)
         name, meta, header = node
-        base_name = meta[:base_name]
         other = visit(header)
 
         mapping =
           if meta[:combine_type] == :many
-            base_name
+            name
           else
-            { Inflector.singularize(name).to_sym => base_name }
+            { Inflector.singularize(name).to_sym => name }
           end
 
-        register_command(base_name, type, meta)
+        register_command(name, type, meta)
 
         if other.size > 0
           [mapping, [type, other]]
@@ -83,7 +82,8 @@ module ROM
         type.create_class(name, type) do |klass|
           if meta[:combine_type]
             klass.use(:associates)
-            klass.associates(:parent, key: meta[:keys].invert.to_a.flatten)
+            keys = meta[:keys].invert.to_a.flatten.map { |k| k.respond_to?(:attribute) ? k.attribute : k }
+            klass.associates(:parent, key: keys)
           end
 
           relation = container.relations[name]

--- a/lib/rom/repository/command_compiler.rb
+++ b/lib/rom/repository/command_compiler.rb
@@ -82,7 +82,7 @@ module ROM
         type.create_class(name, type) do |klass|
           if meta[:combine_type]
             klass.use(:associates)
-            keys = meta[:keys].invert.to_a.flatten.map { |k| k.respond_to?(:attribute) ? k.attribute : k }
+            keys = meta[:keys].invert.to_a.flatten
             klass.associates(:parent, key: keys)
           end
 

--- a/lib/rom/repository/command_proxy.rb
+++ b/lib/rom/repository/command_proxy.rb
@@ -7,7 +7,7 @@ module ROM
 
       def initialize(command)
         @command = command
-        @root = Inflector.singularize(command.relation.name).to_sym
+        @root = Inflector.singularize(command.name).to_sym
       end
 
       def call(input)

--- a/lib/rom/repository/command_proxy.rb
+++ b/lib/rom/repository/command_proxy.rb
@@ -7,7 +7,7 @@ module ROM
 
       def initialize(command)
         @command = command
-        @root = Inflector.singularize(command.name).to_sym
+        @root = Inflector.singularize(command.name.relation).to_sym
       end
 
       def call(input)

--- a/lib/rom/repository/header_builder.rb
+++ b/lib/rom/repository/header_builder.rb
@@ -29,10 +29,11 @@ module ROM
       end
 
       def visit_relation(node, meta = {})
-        name, meta, header = node
+        relation_name, meta, header = node
+        name = meta[:combine_name] || relation_name
 
         model = meta.fetch(:model) do
-          struct_builder[meta.fetch(:base_name), header]
+          struct_builder[meta.fetch(:dataset), header]
         end
 
         options = [visit(header, meta), model: model]
@@ -55,7 +56,7 @@ module ROM
 
       def visit_attribute(name, meta = {})
         if meta[:wrap]
-          [name, from: :"#{meta[:base_name]}_#{name}"]
+          [name, from: :"#{meta[:dataset]}_#{name}"]
         else
           [name]
         end

--- a/lib/rom/repository/relation_proxy.rb
+++ b/lib/rom/repository/relation_proxy.rb
@@ -20,7 +20,7 @@ module ROM
       option :name, type: Symbol
       option :mappers, reader: true, default: proc { MapperBuilder.new }
       option :meta, reader: true, type: Hash, default: EMPTY_HASH
-      option :registry, type: Hash, default: EMPTY_HASH, reader: true
+      option :registry, type: RelationRegistry, default: proc { RelationRegistry.new }, reader: true
 
       # @attr_reader [ROM::Relation::Lazy] relation Decorated relation
       attr_reader :relation

--- a/lib/rom/repository/relation_proxy/combine.rb
+++ b/lib/rom/repository/relation_proxy/combine.rb
@@ -31,7 +31,7 @@ module ROM
               end
             else
               assoc = relation.schema.associations[type]
-              curried = registry[assoc.target].for_combine(assoc)
+              curried = registry[assoc.target.relation].for_combine(assoc)
               keys = assoc.combine_keys(__registry__)
               (result[assoc.result] ||= {})[assoc.name] = [curried, keys]
             end
@@ -111,7 +111,7 @@ module ROM
         #
         # @api private
         def combine_keys(source, target, type)
-          assoc = source.schema && source.schema.associations[target.base_name]
+          assoc = source.schema && source.schema.associations[target.name.dataset]
 
           if assoc
             assoc.combine_keys(__registry__)
@@ -136,13 +136,13 @@ module ROM
         #
         # @api private
         def combine_method(other, keys)
-          custom_name = :"for_#{other.base_name}"
+          custom_name = :"for_#{other.name.dataset}"
 
           if relation.respond_to?(custom_name)
             __send__(custom_name)
           else
             for_combine(
-              (other.schema && other.schema.associations[base_name]) || keys
+              (other.schema && other.schema.associations[name.dataset]) || keys
             )
           end
         end
@@ -154,9 +154,9 @@ module ROM
         # @api private
         def combine_tuple_key(arity)
           if arity == :one
-            Inflector.singularize(base_name).to_sym
+            Inflector.singularize(base_name.relation).to_sym
           else
-            base_name
+            base_name.relation
           end
         end
 
@@ -169,7 +169,8 @@ module ROM
         #
         # @api private
         def combined(name, keys, type)
-          with(name: name, meta: { keys: keys, combine_type: type })
+          meta = { keys: keys, combine_type: type, combine_name: name }
+          with(name: name, meta: meta)
         end
       end
     end

--- a/lib/rom/repository/relation_proxy/combine.rb
+++ b/lib/rom/repository/relation_proxy/combine.rb
@@ -31,7 +31,7 @@ module ROM
               end
             else
               assoc = relation.schema.associations[type]
-              curried = registry[assoc.target.relation].for_combine(assoc)
+              curried = registry[assoc.target].for_combine(assoc)
               keys = assoc.combine_keys(__registry__)
               (result[assoc.result] ||= {})[assoc.name] = [curried, keys]
             end

--- a/lib/rom/repository/relation_proxy/wrap.rb
+++ b/lib/rom/repository/relation_proxy/wrap.rb
@@ -21,7 +21,7 @@ module ROM
           }
 
           relation = wraps.reduce(self) { |a, e|
-            a.relation.for_wrap(e.meta.fetch(:keys), e.base_name)
+            a.relation.for_wrap(e.meta.fetch(:keys), e.base_name.relation)
           }
 
           __new__(relation, meta: { wraps: wraps })
@@ -52,7 +52,7 @@ module ROM
         #
         # @api private
         def wrapped(name, keys)
-          with(name: name, meta: { keys: keys, wrap: true })
+          with(name: name, meta: { keys: keys, wrap: true, combine_name: name })
         end
       end
     end

--- a/lib/rom/repository/struct_builder.rb
+++ b/lib/rom/repository/struct_builder.rb
@@ -89,8 +89,8 @@ module ROM
       end
 
       def visit_relation(node)
-        name, * = node
-        name
+        relation_name, meta, * = node
+        meta[:combine_name] || relation_name.relation
       end
 
       def visit_attribute(node)

--- a/spec/integration/command_spec.rb
+++ b/spec/integration/command_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe ROM::Repository, '#command' do
 
         comment = create_comment.(author: 'gerybabooma', body: 'DIS GUY MUST BE A ALIEN OR SUTIN')
 
-        expect(comment.id).to eql(1)
+        expect(comment.message_id).to eql(1)
         expect(comment.author).to eql('gerybabooma')
         expect(comment.body).to eql('DIS GUY MUST BE A ALIEN OR SUTIN')
       end

--- a/spec/integration/command_spec.rb
+++ b/spec/integration/command_spec.rb
@@ -142,6 +142,20 @@ RSpec.describe ROM::Repository, '#command' do
       expect(user.task.tag.id).to_not be(nil)
       expect(user.task.tag.name).to eql('red')
     end
+
+    context 'relation with a custom dataset name' do
+      let(:repo) { Class.new(ROM::Repository[:comments]).new(rom) }
+
+      it 'allows configuring a create command' do
+        create_comment = repo.command(create: :comments)
+
+        comment = create_comment.(author: 'gerybabooma', body: 'DIS GUY MUST BE A ALIEN OR SUTIN')
+
+        expect(comment.id).to eql(1)
+        expect(comment.author).to eql('gerybabooma')
+        expect(comment.body).to eql('DIS GUY MUST BE A ALIEN OR SUTIN')
+      end
+    end
   end
 
   context ':update' do

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe 'ROM repository' do
   end
 
   it 'loads an parent via custom fks' do
+    pending 'Does not work with an arbitrary combine name'
     post = repo.posts.combine(:author).where(title: 'Hello From Jane').one
 
     expect(post.title).to eql('Hello From Jane')

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -111,4 +111,17 @@ RSpec.describe 'ROM repository' do
       expect(repo.dummy.to_a).to eql([])
     end
   end
+
+  context 'not common naming conventions' do
+    it 'fetches comments with likes' do
+      comments = comments_repo.comments_with_likes.to_a
+
+      expect(comments.size).to be(2)
+      expect(comments[0].author).to eql('Jane')
+      expect(comments[0].likes[0].author).to eql('Joe')
+      expect(comments[0].likes[1].author).to eql('Anonymous')
+      expect(comments[1].author).to eql('Joe')
+      expect(comments[1].likes[0].author).to eql('Jane')
+    end
+  end
 end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe 'ROM repository' do
   end
 
   it 'loads an parent via custom fks' do
-    pending 'Does not work with an arbitrary combine name'
     post = repo.posts.combine(:author).where(title: 'Hello From Jane').one
 
     expect(post.title).to eql('Hello From Jane')

--- a/spec/shared/database.rb
+++ b/spec/shared/database.rb
@@ -13,7 +13,8 @@ RSpec.shared_context 'database' do
   before do
     conn.loggers << LOGGER
 
-    [:tags, :tasks, :posts, :users, :posts_labels, :labels, :messages].each { |table| conn.drop_table?(table) }
+    [:tags, :tasks, :posts, :users, :posts_labels, :labels,
+     :reactions, :messages].each { |table| conn.drop_table?(table) }
 
     conn.create_table :users do
       primary_key :id
@@ -51,9 +52,15 @@ RSpec.shared_context 'database' do
     end
 
     conn.create_table :messages do
-      primary_key :id
+      primary_key :message_id
       column :author, String
       column :body, String
+    end
+
+    conn.create_table :reactions do
+      primary_key :reaction_id
+      foreign_key :message_id, :messages, null: false
+      column :author, String
     end
   end
 end

--- a/spec/shared/database.rb
+++ b/spec/shared/database.rb
@@ -13,7 +13,7 @@ RSpec.shared_context 'database' do
   before do
     conn.loggers << LOGGER
 
-    [:tags, :tasks, :posts, :users, :posts_labels, :labels].each { |table| conn.drop_table?(table) }
+    [:tags, :tasks, :posts, :users, :posts_labels, :labels, :messages].each { |table| conn.drop_table?(table) }
 
     conn.create_table :users do
       primary_key :id
@@ -48,6 +48,12 @@ RSpec.shared_context 'database' do
       foreign_key :post_id, :labels, null: false, on_delete: :cascade
       foreign_key :label_id, :labels, null: false, on_delete: :cascade
       primary_key [:post_id, :label_id]
+    end
+
+    conn.create_table :messages do
+      primary_key :id
+      column :author, String
+      column :body, String
     end
   end
 end

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -55,7 +55,7 @@ RSpec.shared_context 'relations' do
 
         associate do
           many :labels, through: :posts_labels
-          belongs :author, relation: :users
+          belongs :users, as: :author
         end
       end
     end

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -72,5 +72,15 @@ RSpec.shared_context 'relations' do
         end
       end
     end
+
+    configuration.relation(:comments) do
+      register_as :comments
+
+      schema(:messages) do
+        attribute :id, ROM::SQL::Types::Serial
+        attribute :author, ROM::SQL::Types::String
+        attribute :body, ROM::SQL::Types::String
+      end
+    end
   end
 end

--- a/spec/shared/relations.rb
+++ b/spec/shared/relations.rb
@@ -77,9 +77,27 @@ RSpec.shared_context 'relations' do
       register_as :comments
 
       schema(:messages) do
-        attribute :id, ROM::SQL::Types::Serial
+        attribute :message_id, ROM::SQL::Types::Serial
         attribute :author, ROM::SQL::Types::String
         attribute :body, ROM::SQL::Types::String
+
+        associate do
+          many :reactions, relation: :likes
+        end
+      end
+    end
+
+    configuration.relation(:likes) do
+      register_as :likes
+
+      schema(:reactions) do
+        attribute :reaction_id, ROM::SQL::Types::Serial
+        attribute :message_id, ROM::SQL::Types::ForeignKey(:messages)
+        attribute :author, ROM::SQL::Types::String
+
+        associate do
+          belongs :messages, relation: :comments
+        end
       end
     end
   end

--- a/spec/shared/repo.rb
+++ b/spec/shared/repo.rb
@@ -57,4 +57,14 @@ RSpec.shared_context('repo') do
       end
     end
   end
+
+  let(:comments_repo) do
+    Class.new(ROM::Repository[:comments]) do
+      relations :likes
+
+      def comments_with_likes
+        aggregate(many: { likes: likes })
+      end
+    end.new(rom)
+  end
 end

--- a/spec/shared/seeds.rb
+++ b/spec/shared/seeds.rb
@@ -19,5 +19,12 @@ RSpec.shared_context 'seeds' do
     conn[:posts_labels].insert post_id: jane_post_id, label_id: blue_id
 
     conn[:posts_labels].insert post_id: joe_post_id, label_id: green_id
+
+    conn[:messages].insert author: 'Jane', body: 'Hello folks'
+    conn[:messages].insert author: 'Joe', body: 'Hello Jane'
+
+    conn[:reactions].insert message_id: 1, author: 'Joe'
+    conn[:reactions].insert message_id: 1, author: 'Anonymous'
+    conn[:reactions].insert message_id: 2, author: 'Jane'
   end
 end

--- a/spec/unit/header_builder_spec.rb
+++ b/spec/unit/header_builder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'header builder', '#call' do
     let(:ast) do
       [:relation, [
         :users,
-        { base_name: :users },
+        { dataset: :users, combine_name: :users },
         [:header, [[:attribute, :id], [:attribute, :name]]]
       ]]
     end
@@ -33,19 +33,19 @@ RSpec.describe 'header builder', '#call' do
     let(:ast) do
       [:relation, [
         :users,
-        { base_name: :users },
+        { dataset: :users, combine_name: :users },
         [
           :header, [
             [:attribute, :id],
             [:attribute, :name],
             [:relation, [
               :tasks,
-              { base_name: :tasks, keys: { id: :user_id }, combine_type: :many },
+              { dataset: :tasks, keys: { id: :user_id }, combine_type: :many, combine_name: :tasks },
               [:header, [[:attribute, :user_id], [:attribute, :title]]]
             ]],
             [:relation, [
               :tags,
-              { base_name: :tags, keys: { id: :user_id }, combine_type: :many },
+              { dataset: :tags, keys: { id: :user_id }, combine_type: :many, combine_name: :tags },
               [:header, [[:attribute, :user_id], [:attribute, :tag]]]
             ]]
           ]]

--- a/spec/unit/relation_proxy_spec.rb
+++ b/spec/unit/relation_proxy_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'loading proxy' do
       expect(users.to_ast).to eql(
         [:relation, [
           :users,
-          { base_name: :users },
+          { dataset: :users },
           [:header, [[:attribute, :id], [:attribute, :name]]]]
         ]
       )
@@ -114,13 +114,13 @@ RSpec.describe 'loading proxy' do
       expect(relation.to_ast).to eql(
         [:relation, [
           :users,
-          { base_name: :users },
+          { dataset: :users },
           [:header, [
             [:attribute, :id],
             [:attribute, :name],
             [:relation, [
-              :user_tasks,
-              { base_name: :tasks, keys: { id: :user_id }, combine_type: :many },
+              :tasks,
+              { dataset: :tasks, keys: { id: :user_id }, combine_type: :many, combine_name: :user_tasks },
               [:header, [[:attribute, :id], [:attribute, :user_id], [:attribute, :title]]]
             ]]
           ]
@@ -134,14 +134,14 @@ RSpec.describe 'loading proxy' do
       expect(relation.to_ast).to eql(
         [:relation, [
           :tags,
-          { base_name: :tags },
+          { dataset: :tags },
           [:header, [
             [:attribute, :id],
             [:attribute, :task_id],
             [:attribute, :name],
             [:relation, [
-              :task,
-              { base_name: :tasks, keys: { id: :task_id }, wrap: true },
+              :tasks,
+              { dataset: :tasks, keys: { id: :task_id }, wrap: true, combine_name: :task },
               [:header, [ [:attribute, :id], [:attribute, :user_id], [:attribute, :title]]]
             ]]
           ]]


### PR DESCRIPTION
Depends on https://github.com/rom-rb/rom/pull/347 and https://github.com/rom-rb/rom-sql/pull/70

Based on the changes in rom and rom-sql I was able to support random table names in relations alongside with new schema definitions. This refactoring reveals a problem with ad hoc combining in schema associations and I had to mark one spec as pending here https://github.com/rom-rb/rom-repository/blob/4fdee4c706e059616b324c19a9db71bf16f432b1/spec/integration/repository_spec.rb#L78 I believe we can support but the [syntax](https://github.com/rom-rb/rom-repository/blob/master/spec/shared/relations.rb#L58) it uses must be changed to `belongs :users, as: :author`.

Current state: not ready, I tried to add first spec with different dataset/relation names and all hell broke loose. It took me two days to came up with something working but now it looks like the overall idea of using simple struct objects for names is good enough to solve the problems.
