### PR TITLE
Add to_s for ROM::Stuct

### DIFF
--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -26,5 +26,14 @@ module ROM
     def [](name)
       instance_variable_get("@#{name}")
     end
+
+    # Return short string representaiton
+    #
+    # @return [String]
+    #
+    # @api public
+    def to_s
+      "#<#{self.class}:0x#{(object_id << 1).to_s(16)}>"
+    end
   end
 end

--- a/spec/unit/struct_builder_spec.rb
+++ b/spec/unit/struct_builder_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe 'struct builder', '#call' do
     expect(user[:name]).to eql('Jane')
 
     expect(Hash[user]).to eql(id: 1, name: 'Jane')
+
+    expect(user.inspect).to eql('#<ROM::Struct[User] id=1 name="Jane">')
+    expect(user.to_s).to match(/\A#<ROM::Struct\[User\]:0x[0-9a-f]+>\z/)
   end
 
   it 'stores struct in the registry' do


### PR DESCRIPTION
I did some research and found out that ruby searches for a constant name instead of calling `.name` or `.to_s` on object's class. That's why I implemented `to_s` myself.
See sources for details http://ruby-doc.org/core-2.3.1/Object.html#method-i-to_s 
