### PR TITLE
Support for struct attributes with reserved names

### DIFF
--- a/lib/rom/repository/struct_attributes.rb
+++ b/lib/rom/repository/struct_attributes.rb
@@ -31,14 +31,16 @@ module ROM
 
       def define_constructor(attributes)
         ivs = attributes.map { |a| "@#{a}" }.join(', ')
-        values = attributes.map { |a| "values[:#{a}]" }.join(', ')
+        values = attributes.map { |a| "values.fetch(:#{a})" }.join(', ')
 
         assignment = attributes.size > 0 ? "#{ivs} = #{values}" : EMPTY_STRING
 
         module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def initialize(values)
-            assert_known_attributes(values)
+            assert_known_attributes(values) if values.size > #{attributes.size}
             #{assignment}
+          rescue KeyError
+            assert_known_attributes(values)
           end
         RUBY
       end

--- a/lib/rom/repository/struct_attributes.rb
+++ b/lib/rom/repository/struct_attributes.rb
@@ -22,7 +22,7 @@ module ROM
             actual = values.keys
             unknown, missing = actual - attributes, attributes - actual
 
-            if unknown.any? || missing.any?
+            if unknown.size > 0 || missing.size > 0
               raise ROM::Struct::InvalidAttributes.new(self.class, missing, unknown)
             end
           end

--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -5,6 +5,17 @@ module ROM
   #
   # @api public
   class Struct
+    # Error on building a struct instance
+    #
+    # @api private
+    class InvalidAttributes < ArgumentError
+      # @api private
+      def initialize(klass, missing, unknown)
+        super("#{klass} attributes " \
+              "missing: #{missing.map(&:inspect).join(', ')}, " \
+              "unknown: #{unknown.map(&:inspect).join(', ')}")
+      end
+    end
     # Coerces a struct to a hash
     #
     # @return [Hash]

--- a/spec/unit/struct_builder_spec.rb
+++ b/spec/unit/struct_builder_spec.rb
@@ -25,4 +25,40 @@ RSpec.describe 'struct builder', '#call' do
   it 'stores struct in the cache' do
     expect(builder.class.cache[input.hash]).to be(builder[*input])
   end
+
+  context 'with reserved keywords as attribute names' do
+    let(:input) { [:users, [:header, [[:attribute, :id], [:attribute, :name],
+                                      [:attribute, :alias], [:attribute, :until]]]] }
+
+    it 'allows to build a struct class without complaining' do
+      struct = builder.class.cache[input.hash]
+
+      user = struct.new(id: 1, name: 'Jane', alias: 'JD', until: Time.new(2030))
+
+      expect(user.id).to be(1)
+      expect(user.name).to eql('Jane')
+      expect(user.alias).to eql('JD')
+      expect(user.until).to eql(Time.new(2030))
+    end
+  end
+
+  it 'raise a friendly error on missing keys' do
+    struct = builder.class.cache[input.hash]
+
+    expect { struct.new(id: 1) }.to raise_error(
+      ROM::Struct::InvalidAttributes,
+      /missing: :name/
+    )
+  end
+
+  it 'raise a friendly error on superflous keys' do
+    struct = builder.class.cache[input.hash]
+
+    expect {
+      struct.new(id: 1, name: 'Jane', foo: 'bar', baz: 'quux')
+    }.to raise_error(
+      ROM::Struct::InvalidAttributes,
+      /unknown: :foo, :baz/
+    )
+  end
 end


### PR DESCRIPTION
This fixes #37 but slows struct initialization a bit (actually 1.5x difference), see https://gist.github.com/flash-gordon/f9b99f8c28f0a0d65902cae18035a45f for details. I also added more friendly errors on missing or unknown keys.
