### PR TITLE
[WIP] Allow nested symbolic combinations.

### DIFF
--- a/lib/rom/repository/relation_proxy/combine.rb
+++ b/lib/rom/repository/relation_proxy/combine.rb
@@ -58,7 +58,7 @@ module ROM
 
           options.each do |key, value|
             if key == :one || key == :many
-              combine_opts[key] = combine_opts_from_relations(value)
+              combine_opts[key].merge!(combine_opts_from_relations(value))
             else
               result, curried, keys = combine_opts_for_assoc(key, value)
               combine_opts[result][key] = [curried, keys]

--- a/lib/rom/repository/relation_proxy/combine.rb
+++ b/lib/rom/repository/relation_proxy/combine.rb
@@ -56,12 +56,12 @@ module ROM
 
           combine_opts = Hash.new { |h, k| h[k] = {} }
 
-          options.each do |(type, relations)|
-            if relations
-              combine_opts[type] = combine_opts_from_relations(relations)
+          options.each do |key, value|
+            if key == :one || key == :many
+              combine_opts[key] = combine_opts_from_relations(value)
             else
-              result, curried, keys = combine_opts_for_assoc(type)
-              combine_opts[result][type] = [curried, keys]
+              result, curried, keys = combine_opts_for_assoc(key, value)
+              combine_opts[result][key] = [curried, keys]
             end
           end
 
@@ -214,9 +214,10 @@ module ROM
         # This is used when a flat list of association names was passed to `combine`
         #
         # @api private
-        def combine_opts_for_assoc(name)
+        def combine_opts_for_assoc(name, opts)
           assoc = relation.associations[name]
           curried = registry[assoc.target.relation].for_combine(assoc)
+          curried = curried.combine(opts) unless opts.nil?
           keys = assoc.combine_keys(__registry__)
           [assoc.result, curried, keys]
         end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe 'ROM repository' do
     expect(repo.users_with_tasks_and_tags.first.to_h).to eql(user_with_task_and_tags.to_h)
   end
 
+  it 'loads nested combined relations using configured associations' do
+    expect(repo.users_with_tasks_and_their_tags)
+      .to eql(user_with_tasks_and_their_tags.to_h)
+  end
+
   it 'loads a wrapped relation' do
     expect(repo.tag_with_wrapped_task.first).to eql(tag_with_task)
   end

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'ROM repository' do
   end
 
   it 'loads nested combined relations using configured associations' do
-    expect(repo.users_with_tasks_and_their_tags)
-      .to eql(user_with_tasks_and_their_tags.to_h)
+    expect(repo.users_with_posts_and_their_labels.first.to_h)
+      .to eql(jane_with_posts.to_h)
   end
 
   it 'loads a wrapped relation' do

--- a/spec/shared/repo.rb
+++ b/spec/shared/repo.rb
@@ -36,8 +36,12 @@ RSpec.shared_context('repo') do
         aggregate(one: tasks.find(title: title))
       end
 
-      def users_with_tasks_and_their_tags
-        combine(tasks: [:tags])
+      def users_with_posts_and_their_labels
+        users.combine(posts: [:labels])
+      end
+
+      def posts_with_labels
+        posts.combine_children(many: labels)
       end
 
       def tasks_for_users(users)

--- a/spec/shared/repo.rb
+++ b/spec/shared/repo.rb
@@ -44,6 +44,10 @@ RSpec.shared_context('repo') do
         posts.combine_children(many: labels)
       end
 
+      def label_with_posts
+        labels.combine_children(one: posts)
+      end
+
       def tasks_for_users(users)
         tasks.for_users(users)
       end

--- a/spec/shared/repo.rb
+++ b/spec/shared/repo.rb
@@ -36,6 +36,10 @@ RSpec.shared_context('repo') do
         aggregate(one: tasks.find(title: title))
       end
 
+      def users_with_tasks_and_their_tags
+        combine(tasks: [:tags])
+      end
+
       def tasks_for_users(users)
         tasks.for_users(users)
       end

--- a/spec/shared/structs.rb
+++ b/spec/shared/structs.rb
@@ -85,6 +85,10 @@ RSpec.shared_context 'structs' do
     user_with_tasks_struct.new(id: 1, name: 'Jane', all_tasks: [task_with_tag])
   end
 
+  let(:user_with_tasks_and_their_tags) do
+    user_with_tasks_struct.new(id: 1, name: 'Jane', all_tasks: [task_with_tag])
+  end
+
   let(:joe) do
     user_struct.new(id: 2, name: 'Joe')
   end

--- a/spec/shared/structs.rb
+++ b/spec/shared/structs.rb
@@ -25,8 +25,8 @@ RSpec.shared_context 'structs' do
     mapper_for(repo.posts_with_labels).model
   end
 
-  let(:label_with_post_struct) do
-    mapper_for(repo.label_with_post).model
+  let(:label_with_posts_struct) do
+    mapper_for(repo.label_with_posts).model
   end
 
   let(:tag_with_task_struct) do
@@ -126,11 +126,11 @@ RSpec.shared_context 'structs' do
   end
 
   let(:label_red) do
-    label_struct.new(id: 1, name: 'red') # , post_id: 1)
+    label_with_posts_struct.new(id: 1, name: 'red', post: 1)
   end
 
   let(:label_blue) do
-    label_struct.new(id: 3, name: 'blue') # , post_id: 1)
+    label_with_posts_struct.new(id: 3, name: 'blue', post: 1)
   end
 
   let(:post_with_label) do

--- a/spec/shared/structs.rb
+++ b/spec/shared/structs.rb
@@ -13,6 +13,22 @@ RSpec.shared_context 'structs' do
     repo.tags.mapper.model
   end
 
+  let(:post_struct) do
+    repo.posts.mapper.model
+  end
+
+  let(:label_struct) do
+    repo.labels.mapper.model
+  end
+
+  let(:post_with_labels_struct) do
+    mapper_for(repo.posts_with_labels).model
+  end
+
+  let(:label_with_post_struct) do
+    mapper_for(repo.label_with_post).model
+  end
+
   let(:tag_with_task_struct) do
     mapper_for(repo.tag_with_wrapped_task).model
   end
@@ -23,6 +39,10 @@ RSpec.shared_context 'structs' do
 
   let(:user_with_task_struct) do
     mapper_for(repo.users_with_task).model
+  end
+
+  let(:user_with_posts_struct) do
+    mapper_for(repo.users_with_posts_and_their_labels).model
   end
 
   let(:task_with_tags_struct) do
@@ -85,10 +105,6 @@ RSpec.shared_context 'structs' do
     user_with_tasks_struct.new(id: 1, name: 'Jane', all_tasks: [task_with_tag])
   end
 
-  let(:user_with_tasks_and_their_tags) do
-    user_with_tasks_struct.new(id: 1, name: 'Jane', all_tasks: [task_with_tag])
-  end
-
   let(:joe) do
     user_struct.new(id: 2, name: 'Joe')
   end
@@ -103,5 +119,24 @@ RSpec.shared_context 'structs' do
 
   let(:joe_task) do
     task_struct.new(id: 1, user_id: 2, title: 'Joe Task')
+  end
+
+  let(:jane_with_posts) do
+    user_with_posts_struct.new(id: 1, name: 'Jane', posts: [post_with_label])
+  end
+
+  let(:label_red) do
+    label_struct.new(id: 1, name: 'red') # , post_id: 1)
+  end
+
+  let(:label_blue) do
+    label_struct.new(id: 3, name: 'blue') # , post_id: 1)
+  end
+
+  let(:post_with_label) do
+    post_with_labels_struct.new(id: 2, title: 'Hello From Jane',
+                                body: 'Jane Post',
+                                author_id: 1,
+                                labels: [label_red, label_blue])
   end
 end


### PR DESCRIPTION
# Purpose
Allow nested combination directives for configured associations.

# Before this PR
`#combine` accepts either a hash with primary keys `:one` and `:many` with values describing target relations, or an array of symbols representing configured associations.

# After this PR
`#combine` also accepts hashes/arrays of symbols. The formal grammar is as follows:
`S → Hash{Symbol => S} | Array<Symbol, Hash{Symbol => S}>`

Example: 
```ruby
{ 
  posts: [ 
    :tags, 
    comments: [:author], 
    author: [:comments, :author]
  ], 
  comments: [:author] 
}
```

# Status
Tests are currently failing because the `labels` of `posts` in the test db are linked via a join table (`posts_labels`), which makes the resulting `labels` have a `post_id` attribute which the `ROM::Struct[Label]` does not accept via constructor. I'm currently not familiar enough with ROM to know exactly what's going on. Any advice? /cc @solnic 