### PR TITLE
Feature/custom changesets

### DIFF
--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -188,9 +188,9 @@ module ROM
         relation = relations[name]
 
         if pk
-          Changeset::Update.new(relation, opts.merge(data: data, primary_key: pk))
+          Changeset::Update.new(relation, opts.merge(__data__: data, primary_key: pk))
         else
-          Changeset::Create.new(relation, opts.merge(data: data))
+          Changeset::Create.new(relation, opts.merge(__data__: data))
         end
       end
     end

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -162,17 +162,23 @@ module ROM
     #
     # @api public
     def changeset(*args)
+      opts = { command_compiler: command_compiler }
+
       if args.size == 2
         name, data = args
       elsif args.size == 3
         name, pk, data = args
       elsif args.size == 1
-        type, relation = args[0].to_a[0]
+        type = args[0]
+
+        if type.is_a?(Class) && type < Changeset
+          return type.new(relations[type.relation], opts)
+        else
+          type, relation = args[0].to_a[0]
+        end
       else
         raise ArgumentError, 'Repository#changeset accepts 1-3 arguments'
       end
-
-      opts = { command_compiler: command_compiler }
 
       if type
         if type.equal?(:delete)

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -45,13 +45,18 @@ module ROM
       }
     end
 
+    # @api public
+    def self.map(&block)
+      @pipe = Class.new(Pipe, &block).new
+    end
+
     # Build default pipe object
     #
     # This can be overridden in a custom changeset subclass
     #
     # @return [Pipe]
     def self.default_pipe
-      Pipe.new
+      @pipe || Pipe.new
     end
 
     # Pipe changeset's data using custom steps define on the pipe
@@ -62,7 +67,7 @@ module ROM
     #
     # @api public
     def map(*steps)
-      with(pipe: steps.reduce(pipe) { |a, e| a >> pipe.class[e] })
+      with(pipe: steps.reduce(pipe) { |a, e| a >> pipe[e] })
     end
 
     # Coerce changeset to a hash

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -1,9 +1,16 @@
+require 'dry/core/class_attributes'
+require 'dry/core/cache'
+
 require 'rom/initializer'
 require 'rom/repository/changeset/pipe'
 
 module ROM
   class Changeset
     extend Initializer
+    extend Dry::Core::Cache
+    extend Dry::Core::ClassAttributes
+
+    defines :relation
 
     # @!attribute [r] relation
     #   @return [Relation] The changeset relation
@@ -22,6 +29,21 @@ module ROM
     # @!attribute [r] command_compiler
     #   @return [Proc] a proc that can compile a command (typically provided by a repo)
     option :command_compiler, reader: true, optional: true
+
+    # Create a changeset class preconfigured for a specific relation
+    #
+    # @example
+    #   class NewUserChangeset < ROM::Changeset::Create[:users]
+    #   end
+    #
+    #   user_repo.changeset(NewUserChangeset).data(name: 'Jane')
+    #
+    # @api public
+    def self.[](relation_name)
+      fetch_or_store(relation_name) {
+        Class.new(self) { relation(relation_name) }
+      }
+    end
 
     # Build default pipe object
     #

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -16,9 +16,9 @@ module ROM
     #   @return [Relation] The changeset relation
     param :relation
 
-    # @!attribute [r] data
+    # @!attribute [r] __data__
     #   @return [Hash] The relation data
-    option :data, reader: true, optional: true
+    option :__data__, reader: true, optional: true, default: proc { nil }
 
     # @!attribute [r] pipe
     #   @return [Changeset::Pipe] data transformation pipe
@@ -78,7 +78,7 @@ module ROM
     #
     # @api public
     def to_h
-      pipe.call(data)
+      pipe.call(__data__)
     end
     alias_method :to_hash, :to_h
 
@@ -93,20 +93,31 @@ module ROM
       self.class.new(relation, options.merge(new_options))
     end
 
+    # Return changeset with data
+    #
+    # @param [Hash] data
+    #
+    # @return [Changeset]
+    #
+    # @api public
+    def data(data)
+      with(__data__: data)
+    end
+
     private
 
     # @api private
     def respond_to_missing?(meth, include_private = false)
-      super || data.respond_to?(meth)
+      super || __data__.respond_to?(meth)
     end
 
     # @api private
     def method_missing(meth, *args, &block)
-      if data.respond_to?(meth)
-        response = data.__send__(meth, *args, &block)
+      if __data__.respond_to?(meth)
+        response = __data__.__send__(meth, *args, &block)
 
         if response.is_a?(Hash)
-          with(options.merge(data: response))
+          with(options.merge(__data__: response))
         else
           response
         end

--- a/lib/rom/repository/changeset.rb
+++ b/lib/rom/repository/changeset.rb
@@ -106,7 +106,7 @@ module ROM
         response = data.__send__(meth, *args, &block)
 
         if response.is_a?(Hash)
-          self.class.new(relation, options.merge(data: response))
+          with(options.merge(data: response))
         else
           response
         end

--- a/lib/rom/repository/changeset/pipe.rb
+++ b/lib/rom/repository/changeset/pipe.rb
@@ -1,9 +1,12 @@
 require 'transproc/registry'
+require 'transproc/transformer'
 
 module ROM
   class Changeset
-    class Pipe
+    class Pipe < Transproc::Transformer
       extend Transproc::Registry
+
+      import Transproc::HashTransformations
 
       attr_reader :processor
 
@@ -16,15 +19,19 @@ module ROM
         data.merge(updated_at: Time.now)
       end
 
-      def initialize(processor = nil)
+      def initialize(processor = self.class.transproc)
         @processor = processor
+      end
+
+      def [](name)
+        self.class[name]
       end
 
       def >>(other)
         if processor
-          self.class.new(processor >> other)
+          Pipe.new(processor >> other)
         else
-          self.class.new(other)
+          Pipe.new(other)
         end
       end
 

--- a/lib/rom/repository/changeset/update.rb
+++ b/lib/rom/repository/changeset/update.rb
@@ -71,7 +71,7 @@ module ROM
       def diff
         @diff ||=
           begin
-            new_tuple = data.to_a
+            new_tuple = __data__.to_a
             ori_tuple = original.to_a
 
             Hash[new_tuple - (new_tuple & ori_tuple)]

--- a/spec/unit/changeset/map_spec.rb
+++ b/spec/unit/changeset/map_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe ROM::Changeset, '.map' do
+  subject(:changeset) do
+    Class.new(ROM::Changeset) do
+      map do
+        unwrap :address
+        rename_keys street: :address_street, city: :address_city, country: :address_country
+      end
+    end.new(relation, data: user_data)
+  end
+
+  let(:relation) { double(:relation) }
+
+  let(:user_data) do
+    { name: 'Jane', address: { street: 'Street 1', city: 'NYC', country: 'US' } }
+  end
+
+  it 'sets up custom data pipe' do
+    expect(changeset.to_h)
+      .to eql(name: 'Jane', address_street: 'Street 1', address_city: 'NYC', address_country: 'US' )
+  end
+end

--- a/spec/unit/changeset/map_spec.rb
+++ b/spec/unit/changeset/map_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ROM::Changeset, '.map' do
         unwrap :address
         rename_keys street: :address_street, city: :address_city, country: :address_country
       end
-    end.new(relation, data: user_data)
+    end.new(relation, __data__: user_data)
   end
 
   let(:relation) { double(:relation) }

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ROM::Changeset do
     it 'returns a hash with changes' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset::Update.new(relation, data: { name: "Jane Doe" }, primary_key: 2)
+      changeset = ROM::Changeset::Update.new(relation, __data__: { name: "Jane Doe" }, primary_key: 2)
 
       expect(changeset.diff).to eql(name: "Jane Doe")
     end
@@ -16,7 +16,7 @@ RSpec.describe ROM::Changeset do
     it 'returns true when data differs from the original tuple' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset::Update.new(relation, data: { name: "Jane Doe" }, primary_key: 2)
+      changeset = ROM::Changeset::Update.new(relation, __data__: { name: "Jane Doe" }, primary_key: 2)
 
       expect(changeset).to be_diff
     end
@@ -24,14 +24,14 @@ RSpec.describe ROM::Changeset do
     it 'returns false when data are equal to the original tuple' do
       expect(relation).to receive(:fetch).with(2).and_return(jane)
 
-      changeset = ROM::Changeset::Update.new(relation, data: { name: "Jane" }, primary_key: 2)
+      changeset = ROM::Changeset::Update.new(relation, __data__: { name: "Jane" }, primary_key: 2)
 
       expect(changeset).to_not be_diff
     end
   end
 
   describe 'quacks like a hash' do
-    subject(:changeset) { ROM::Changeset::Create.new(relation, data: data) }
+    subject(:changeset) { ROM::Changeset::Create.new(relation, __data__: data) }
 
     let(:data) { instance_double(Hash) }
 
@@ -47,7 +47,7 @@ RSpec.describe ROM::Changeset do
       new_changeset = changeset.merge(foo: 'bar')
 
       expect(new_changeset).to be_instance_of(ROM::Changeset::Create)
-      expect(new_changeset.options).to eql(changeset.options.merge(data: { foo: 'bar' }))
+      expect(new_changeset.options).to eql(changeset.options.merge(__data__: { foo: 'bar' }))
       expect(new_changeset.to_h).to eql(foo: 'bar')
     end
 

--- a/spec/unit/repository/changeset_spec.rb
+++ b/spec/unit/repository/changeset_spec.rb
@@ -72,4 +72,30 @@ RSpec.describe ROM::Repository, '#changeset' do
       expect(relation.one).to be(nil)
     end
   end
+
+  describe 'custom changeset class' do
+    let(:changeset) do
+      repo.changeset(changeset_class[:users]).with(data: {})
+    end
+
+    let(:changeset_class) do
+      Class.new(ROM::Changeset::Create) do
+        def to_h
+          data.merge(name: 'Jane')
+        end
+      end
+    end
+
+    it 'has data' do
+      expect(changeset.to_h).to eql(name: 'Jane')
+    end
+
+    it 'has relation' do
+      expect(changeset.relation).to be(repo.users)
+    end
+
+    it 'can return a dedicated command' do
+      expect(changeset.command.call).to eql(id: 1, name: 'Jane')
+    end
+  end
 end

--- a/spec/unit/repository/changeset_spec.rb
+++ b/spec/unit/repository/changeset_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe ROM::Repository, '#changeset' do
+  subject(:repo) do
+    Class.new(ROM::Repository) { relations :users }.new(rom)
+  end
+
+  include_context 'database'
+  include_context 'relations'
+
+  describe ROM::Changeset::Create do
+    let(:changeset) do
+      repo.changeset(:users, name: 'Jane')
+    end
+
+    it 'has data' do
+      expect(changeset.to_h).to eql(name: 'Jane')
+    end
+
+    it 'has relation' do
+      expect(changeset.relation).to be(repo.users)
+    end
+
+    it 'can return a dedicated command' do
+      expect(changeset.command.call).to eql(id: 1, name: 'Jane')
+    end
+  end
+
+  describe ROM::Changeset::Update do
+    let(:changeset) do
+      repo.changeset(:users, user[:id], name: 'Jane Doe')
+    end
+
+    let(:user) do
+      repo.command(:create, repo.users).call(name: 'Jane')
+    end
+
+    it 'has data' do
+      expect(changeset.to_h).to eql(name: 'Jane Doe')
+    end
+
+    it 'has diff' do
+      expect(changeset.diff).to eql(name: 'Jane Doe')
+    end
+
+    it 'has relation' do
+      expect(changeset.relation).to be(repo.users)
+    end
+
+    it 'can return a dedicated command' do
+      expect(changeset.command.call).to eql(id: 1, name: 'Jane Doe')
+    end
+  end
+
+  describe ROM::Changeset::Delete do
+    let(:changeset) do
+      repo.changeset(delete: relation)
+    end
+
+    let(:relation) do
+      repo.users.by_pk(user[:id])
+    end
+
+    let(:user) do
+      repo.command(:create, repo.users).call(name: 'Jane')
+    end
+
+    it 'has relation' do
+      expect(changeset.relation).to eql(relation)
+    end
+
+    it 'can return a dedicated command' do
+      expect(changeset.command.call.to_h).to eql(id: 1, name: 'Jane')
+      expect(relation.one).to be(nil)
+    end
+  end
+end

--- a/spec/unit/repository/changeset_spec.rb
+++ b/spec/unit/repository/changeset_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe ROM::Repository, '#changeset' do
 
   describe 'custom changeset class' do
     let(:changeset) do
-      repo.changeset(changeset_class[:users]).with(data: {})
+      repo.changeset(changeset_class[:users]).data({})
     end
 
     let(:changeset_class) do
       Class.new(ROM::Changeset::Create) do
         def to_h
-          data.merge(name: 'Jane')
+          __data__.merge(name: 'Jane')
         end
       end
     end


### PR DESCRIPTION
This adds a way of defining custom changeset classes, with the ability to pre-configure which relation should be used for a particular changeset class. Repositories can build these custom changesets and configure them properly.

### API

``` ruby
module Changesets
  # custom changeset with additional data transformation logic
  class NewUser < ROM::Changeset::Create[:users]
    map do
      unwrap :address, prefix: true
      add_timestamps
    end
  end
end

# then you can use it with repos
user_changeset = user_repo.
  changeset(Changesets::NewUser).
  with(data: { name: 'Jane', address: { street: 'Street 1', city: 'NYC', country: 'US' } })

user_repo.create(user_changeset).to_h
# { id: 1, name: 'Jane', address_street: 'Street 1', address_city: 'NYC', address_country: 'US' }
```

### TODO

- [x] add ability to define custom changeset classes
- [x] extend `Repository#changeset` with support for returning custom changesets
- [x] extend `Changeset` with support for custom data transformations via `map` DSL