### PR TITLE
Reproduce problem with struct objects

### DIFF
--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe 'ROM repository' do
     expect(repo.task_with_owner.first).to eql(task_with_owner)
   end
 
+  it 'returns struct object for first and last methods' do
+    expect(repo.task_with_user.first).to be_a ROM::Struct
+    expect(repo.task_with_user.last).to be_a ROM::Struct
+  end
+
   it 'loads a combined relation with many children' do
     expect(repo.users_with_tasks.to_a).to match_array([jane_with_tasks, joe_with_tasks])
   end


### PR DESCRIPTION
Hey, after searching a problem in this bug (https://github.com/hanami/model/issues/380#issuecomment-279880571) I found that rom `#last` method returns hash instead `ROM::Struct` object.

That's why I created failed test case for this problem. Thanks!