### PR TITLE
Use struct name in NoMethodError for structs with long inspection

### DIFF
--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -62,5 +62,18 @@ module ROM
     def fetch(name)
       __send__(name)
     end
+
+    private
+
+    def method_missing(m, *args)
+      inspected = inspect
+      trace = caller
+
+      # This is how MRI currently works
+      # see func name_err_mesg_to_str in error.c
+      name = inspected.size > 65 ? to_s : inspected
+
+      raise NoMethodError.new("undefined method `#{ m }' for #{ name }", m, args).tap { |e| e.set_backtrace(trace) }
+    end
   end
 end

--- a/spec/unit/struct_builder_spec.rb
+++ b/spec/unit/struct_builder_spec.rb
@@ -69,4 +69,30 @@ RSpec.describe 'struct builder', '#call' do
       Dry::Struct::Error, /:name is missing/
     )
   end
+
+  context 'name errors' do
+    let(:struct) { builder.class.cache[input.hash] }
+
+    context 'missing method on instance' do
+      it 'uses inspect and class name for small structs' do
+        user = struct.new(id: 1, name: 'Jane')
+
+        expect { user.missing }.
+          to raise_error(
+               NoMethodError,
+               %r{undefined method `missing' for #<ROM::Struct\[User\] id=1 name="Jane">}
+             )
+      end
+
+      it 'uses class name in name errors' do
+        user = struct.new(id: 1, name: 'J' * 50)
+
+        expect { user.missing }.
+          to raise_error(
+               NoMethodError,
+               %r{undefined method `missing' for #<ROM::Struct\[User\]:0x\h+>}
+             )
+      end
+    end
+  end
 end


### PR DESCRIPTION
I found that ruby has a weird behavior for representing NamerError exceptions (NoMethodError is a subclass of NameError). When the inspection result of an object exceeds 65 characters Ruby uses object's class path for the error message. Not to mention it's very unexpected and hidden behavior it does not use `.name` method defined for the class of an object. Instead it resolves the namespace chain which is empty for an anonymous class and that's why we get a rather unfriendly error for struct objects which are all anonymous because of their dynamic nature. That said I started to work on this after seeing exceptions like NoMethodError Exception: `undefined method 'foo' for #<#<Class:0x007fe46e06a680>:0x007fe46c4ac5d8>`. Meh.

This PR `#method_missing` to ROM::Struct which takes the job of raising an error in its own hands, but this comes with a couple of trade-offs. The first is that ATM we cannot mixin the receiver into the error. I cannot fix it without subclassing NoMethodError or patching it which is unacceptable FWIW. Lacking of receiver leads to incompatibility with "Did you mean ...?" and this is unfortunate. See https://bugs.ruby-lang.org/issues/12041 for details on this. The second is that this only fixes missing method errors on instances and does not offer any improvement for other sorts of name errors, e.g. missing constants, missing methods on a struct class and so on.

There is another way. We could use real constant names for user structs so that ruby will resolve constant name without an issue. I know we use a relation name as a constant name and two different relations with different headers could have the same name, so this is a problem. Happily we don't have to keep a constant after it was assigned to a class. Consider this:
```ruby
 $ irb
# Two anonymous classes
2.4.0 :001 > a = Class.new
 => #<Class:0x007ff46c856c50>
2.4.0 :002 > b = Class.new
 => #<Class:0x007ff46d811d70>
2.4.0 :003 > a.foo
# Meh, ugly error
NoMethodError: undefined method `foo' for #<Class:0x007ff46c856c50>
2.4.0 :004 > ::Foo = a
 => Foo
2.4.0 :005 > a.foo
# Constant name assigned
NoMethodError: undefined method `foo' for Foo:Class
2.4.0 :006 > Object.send(:remove_const, :Foo)
 => Foo
2.4.0 :007 > a.foo
# It still works!
NoMethodError: undefined method `foo' for Foo:Class
2.4.0 :008 > ::Foo = b
 => Foo
2.4.0 :009 > Object.send(:remove_const, :Foo)
 => Foo
2.4.0 :010 > b.foo
# Works fine for other class!
NoMethodError: undefined method `foo' for Foo:Class
2.4.0 :011 > a.foo
# And still works for a
NoMethodError: undefined method `foo' for Foo:Class
2.4.0 :012 >
```
I'd send a PR with this, however the naming convention we're using is not acceptable for Ruby, constant names like `[User]` or `Struct[User]` are not allowed. But we could come up with `Struct::User`.

@solnic, let me know your thoughts