### PR TITLE
Try to infer assoc name for Changeset#associate

### DIFF
--- a/lib/rom/repository/changeset/stateful.rb
+++ b/lib/rom/repository/changeset/stateful.rb
@@ -187,7 +187,7 @@ module ROM
       # @param [Symbol] assoc The association identifier from schema
       #
       # @api public
-      def associate(other, name)
+      def associate(other, name = Associated.infer_assoc_name(other))
         Associated.new(self, associations: { name => other })
       end
 

--- a/spec/unit/changeset/associate_spec.rb
+++ b/spec/unit/changeset/associate_spec.rb
@@ -79,10 +79,21 @@ RSpec.describe ROM::Changeset, '#associate' do
     it 'associates child with multiple parents' do
       changeset = task_repo.changeset(title: 'Test 1').
                     associate(jane, :user).
-                    associate(project, :project)
+                    associate(project)
 
       expect(changeset.commit).
         to include(user_id: jane.id, project_id: project.id, title: 'Test 1')
+    end
+
+    it 'raises when assoc name cannot be inferred' do
+      other = Class.new do
+        def self.schema
+          []
+        end
+      end.new
+
+      expect { task_repo.changeset(title: 'Test 1').associate(other) }.
+        to raise_error(ArgumentError, /can't infer association name for/)
     end
   end
 


### PR DESCRIPTION
This uses a simple approach where we look for a PK attribute and take
its :source meta info which points to the relation. It'll only work
with auto-generated structs and relations. If you want to use custom
structs then their PKs must include `:source` meta info.