### PR TITLE
Using mapped relation with a custom changeset

### DIFF
--- a/lib/rom/repository/changeset/create.rb
+++ b/lib/rom/repository/changeset/create.rb
@@ -7,6 +7,10 @@ module ROM
     # @api public
     class Create < Stateful
       command_type :create
+
+      def command
+        super.new(relation)
+      end
     end
   end
 end

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -26,8 +26,12 @@ RSpec.describe 'Using changesets' do
       }.new(rom)
     end
 
-    let(:custom_changeset) do
+    let(:create_changeset) do
       Class.new(ROM::Changeset::Create)
+    end
+
+    let(:update_changeset) do
+      Class.new(ROM::Changeset::Update)
     end
 
     it 'can be passed to a command' do
@@ -91,10 +95,20 @@ RSpec.describe 'Using changesets' do
       expect(result.updated_at).to be_instance_of(Time)
     end
 
-    it 'preserves relation mappers' do
+    it 'preserves relation mappers with create' do
       changeset = repo.
-                    changeset(custom_changeset).
+                    changeset(create_changeset).
                     new(repo.users.relation.as(:user)).
+                    data(name: 'Joe Dane')
+
+      expect(changeset.commit).to eql(Test::User.new(id: 1, name: 'Joe Dane'))
+    end
+
+    it 'preserves relation mappers with update' do
+      repo.create(name: 'John Doe')
+      changeset = repo.
+                    changeset(update_changeset).
+                    new(repo.users.relation.as(:user).by_pk(1)).
                     data(name: 'Joe Dane')
 
       expect(changeset.commit).to eql(Test::User.new(id: 1, name: 'Joe Dane'))


### PR DESCRIPTION
I added a failing spec for the subject. As far as I can tell it fails because inserts are handled differently by [PostgreSQL](https://github.com/rom-rb/rom-sql/blob/63bbb879cdfcdd0823b27c65b34af4aaeda196a8/lib/rom/sql/extensions/postgres/commands.rb#L12-L16) and [other databases](https://github.com/rom-rb/rom-sql/blob/63bbb879cdfcdd0823b27c65b34af4aaeda196a8/lib/rom/sql/commands/create.rb#L47-L50). PG's command doesn't use the mapper