### PR TITLE
calculate diff only with respect to keys present on the original tuple

### DIFF
--- a/lib/rom/repository/changeset/update.rb
+++ b/lib/rom/repository/changeset/update.rb
@@ -81,6 +81,7 @@ module ROM
             ori_tuple = original.to_a
 
             Hash[new_tuple - (new_tuple & ori_tuple)]
+              .slice(*original.keys)
           end
       end
     end

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe ROM::Changeset do
 
       expect(changeset.diff).to eql(name: "Jane Doe")
     end
+
+    it 'does not consider keys that are not present on the original tuple' do
+      expect(relation).to receive(:one).and_return(jane)
+
+      changeset = ROM::Changeset::Update.new(relation, __data__: { foo: "bar" })
+
+      expect(changeset.diff).to eql({})
+    end
   end
 
   describe '#diff?' do
@@ -47,6 +55,14 @@ RSpec.describe ROM::Changeset do
       expect(relation).to receive(:one).and_return(jane)
 
       changeset = ROM::Changeset::Update.new(relation, __data__: { name: "Jane" })
+
+      expect(changeset).to_not be_diff
+    end
+
+    it 'returns false when data contains keys that are not available on the original tuple' do
+      expect(relation).to receive(:one).and_return(jane)
+
+      changeset = ROM::Changeset::Update.new(relation, __data__: { foo: "bar" })
 
       expect(changeset).to_not be_diff
     end


### PR DESCRIPTION
I don't know, if you consider this change useful with respect to how additional keys are when persisting data to the a database, but I found this useful, e.g. when initializing a changeset with data coming from a validation, where this validation used some "virtual" data.