### PR TITLE
Injecting dependencies into changesets via options

### DIFF
--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -227,22 +227,21 @@ module ROM
     def changeset(*args)
       opts = { command_compiler: command_compiler }
 
-      if args.size == 2
+      if args[0].is_a?(Class) && args.size <= 3
+        klass = args[0]
+        opts = opts.merge(args[1]) if args[1].respond_to?(:to_hash)
+
+        if klass < Changeset
+          return klass.new(relations[klass.relation], opts)
+        else
+          raise ArgumentError, "+#{klass.name}+ is not a Changeset subclass"
+        end
+      elsif args.size == 2
         name, data = args
       elsif args.size == 3
         name, pk, data = args
       elsif args.size == 1
-        if args[0].is_a?(Class)
-          klass = args[0]
-
-          if klass < Changeset
-            return klass.new(relations[klass.relation], opts)
-          else
-            raise ArgumentError, "+#{klass.name}+ is not a Changeset subclass"
-          end
-        else
-          type, relation = args[0].to_a[0]
-        end
+        type, relation = args[0].to_a[0]
       else
         raise ArgumentError, 'Repository#changeset accepts 1-3 arguments'
       end

--- a/lib/rom/repository/changeset/stateful.rb
+++ b/lib/rom/repository/changeset/stateful.rb
@@ -18,7 +18,7 @@ module ROM
       # @!attribute [r] pipe
       #   @return [Changeset::Pipe] data transformation pipe
       #   @api private
-      option :pipe, accept: [Proc, Pipe], default: -> { self.class.default_pipe(self) }
+      option :pipe, accept: [Proc, Pipe], default: -> { nil }
 
       # Define a changeset mapping
       #
@@ -82,6 +82,12 @@ module ROM
       # @api private
       def self.pipes
         @__pipes__
+      end
+
+      # Initialize default pipe with self after self itself was initialized
+      def initialize(*args)
+        super
+        @pipe ||= self.class.default_pipe(self)
       end
 
       # Pipe changeset's data using custom steps define on the pipe

--- a/spec/unit/changeset/map_spec.rb
+++ b/spec/unit/changeset/map_spec.rb
@@ -81,4 +81,33 @@ RSpec.describe ROM::Changeset, '.map' do
       expect(klass.pipes).to eql(changeset.class.pipes)
     end
   end
+
+  context 'injecting dependencies to custom blocks' do
+    let(:relation) { double(:relation) }
+    let(:user_data) { { name: 'Jane' } }
+
+    it 'works after initialization with optional dependencies' do
+      changeset = Class.new(ROM::Changeset::Create[:users]) do
+        option :dep, reader: true, optional: true
+
+        map do |tuple|
+          tuple.merge(dep: dep)
+        end
+      end.new(relation).with(dep: "foo").data(user_data)
+
+      expect(changeset.to_h).to eql(name: 'Jane', dep: 'foo')
+    end
+
+    it 'works on initialization' do
+      changeset = Class.new(ROM::Changeset::Create[:users]) do
+        option :dep, reader: true
+
+        map do |tuple|
+          tuple.merge(dep: dep)
+        end
+      end.new(relation, dep: "foo").data(user_data)
+
+      expect(changeset.to_h).to eql(name: 'Jane', dep: 'foo')
+    end
+  end
 end

--- a/spec/unit/repository/changeset_spec.rb
+++ b/spec/unit/repository/changeset_spec.rb
@@ -174,6 +174,22 @@ RSpec.describe ROM::Repository, '#changeset' do
         expect(changeset.commit).to eql(id: 1, name: 'Jade Doe')
       end
     end
+
+    context 'with a dependency' do
+      let(:changeset) do
+        repo.changeset(changeset_class[:users], dep: "foo").data({})
+      end
+
+      let(:changeset_class) do
+        Class.new(ROM::Changeset::Create) do
+          option :dep, reader: true
+        end
+      end
+
+      it 'has the dependency as attribute' do
+        expect(changeset.dep).to eql('foo')
+      end
+    end
   end
 
   it 'raises ArgumentError when unknown type was used' do


### PR DESCRIPTION
I think the documented API on http://rom-rb.org/learn/repositories/custom-changesets/ on using dependencies is pretty useful, but unfortunately it doesn't work as described :) So I added these two commit: the first to comply with the documented API (except the `option` has to be `optional: true`) and the second to be able to pass the dependencies on initialization rather than afterwards with `#with`.

I know: `option :pipe ..., default: ->{ nil }` isn't that beautiful.