### PR TITLE
Use pipe's output in Changeset::Update#diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v1.3.3 to-be-released
+
+### Added
+
+* `Changeset#extend` to exclude steps from the `#diff` output, this allows
+  to filter out timestamp changes prior to updates so that we can avoid
+  hitting the database in case of timestamp-only changes. You still can call `.map(:touch)`
+  if you want to have `updated_at` refreshed unconditionally (flash-gordon)
+
 # v1.3.2 2017-05-02
 
 ### Fixed

--- a/lib/rom/repository/changeset/pipe.rb
+++ b/lib/rom/repository/changeset/pipe.rb
@@ -29,6 +29,7 @@ module ROM
 
       param :processor, default: -> { self.class.transproc }
       option :diff_processor, optional: true
+      option :use_for_diff, optional: true, default: -> { true }
 
       def self.[](name)
         container[name]
@@ -46,7 +47,7 @@ module ROM
         end
       end
 
-      def compose(other, for_diff: false)
+      def compose(other, for_diff: other.is_a?(Pipe) ? other.use_for_diff : false)
         new_proc = processor ? processor >> other : other
 
         if for_diff

--- a/lib/rom/repository/changeset/pipe.rb
+++ b/lib/rom/repository/changeset/pipe.rb
@@ -25,11 +25,10 @@ module ROM
     #
     # @api private
     class Pipe < Transproc::Transformer[PipeRegistry]
-      attr_reader :processor
+      extend Initializer
 
-      def initialize(processor = self.class.transproc)
-        @processor = processor
-      end
+      param :processor, default: -> { self.class.transproc }
+      option :diff_processor, optional: true
 
       def self.[](name)
         container[name]
@@ -47,13 +46,17 @@ module ROM
         end
       end
 
-      def >>(other)
-        if processor
-          Pipe.new(processor >> other)
+      def compose(other, for_diff: false)
+        new_proc = processor ? processor >> other : other
+
+        if for_diff
+          diff_proc = diff_processor ? diff_processor >> other : other
+          new(new_proc, diff_processor: diff_proc)
         else
-          Pipe.new(other)
+          new(new_proc)
         end
       end
+      alias_method :>>, :compose
 
       def call(data)
         if processor
@@ -61,6 +64,26 @@ module ROM
         else
           data
         end
+      end
+
+      def for_diff(data)
+        if diff_processor
+          diff_processor.call(data)
+        else
+          data
+        end
+      end
+
+      def with(opts)
+        if opts.empty?
+          self
+        else
+          Pipe.new(processor, options.merge(opts))
+        end
+      end
+
+      def new(processor, opts = EMPTY_HASH)
+        Pipe.new(processor, options.merge(opts))
       end
     end
   end

--- a/lib/rom/repository/changeset/stateful.rb
+++ b/lib/rom/repository/changeset/stateful.rb
@@ -65,7 +65,7 @@ module ROM
 
       def self.extend(*, &block)
         if block
-          map(for_diff: false, &block)
+          map(use_for_diff: false, &block)
         else
           super
         end

--- a/lib/rom/repository/changeset/stateful.rb
+++ b/lib/rom/repository/changeset/stateful.rb
@@ -63,6 +63,14 @@ module ROM
         end
       end
 
+      # Define a changeset mapping excluded from diffs
+      #
+      # @see Changeset::Stateful.map
+      # @see Changeset::Stateful#extend
+      #
+      # @return [Array<Pipe>, Transproc::Function>]
+      #
+      # @api public
       def self.extend(*, &block)
         if block
           map(use_for_diff: false, &block)
@@ -112,7 +120,7 @@ module ROM
       #   Apply mapping using built-in transformations and a custom block
       #
       #   @example
-      #     changeset.map(:touch) { |tuple| tuple.merge(status: 'published') }
+      #     changeset.map(:add_timestamps) { |tuple| tuple.merge(status: 'published') }
       #
       #   @param [Array<Symbol>] steps A list of mapping steps
       #
@@ -123,6 +131,19 @@ module ROM
         extend(*steps, for_diff: true, &block)
       end
 
+      # Pipe changeset's data using custom steps define on the pipe.
+      # You should use #map instead except updating timestamp fields.
+      # Calling changeset.extend builds a pipe that excludes certain
+      # steps for generating the diff. Currently the only place where
+      # it is used is update changesets with the `:touch` step, i.e.
+      # `changeset.extend(:touch).diff` will exclude `:updated_at`
+      # from the diff.
+      #
+      # @see Changeset::Stateful#map
+      #
+      # @return [Changeset]
+      #
+      # @api public
       def extend(*steps, **options, &block)
         if block
           if steps.size > 0

--- a/lib/rom/repository/changeset/update.rb
+++ b/lib/rom/repository/changeset/update.rb
@@ -41,16 +41,6 @@ module ROM
         @original ||= Hash(relation.one)
       end
 
-      # Return diff hash sent through the pipe
-      #
-      # @return [Hash]
-      #
-      # @api public
-      def to_h
-        pipe.call(diff)
-      end
-      alias_method :to_hash, :to_h
-
       # Return true if there's a diff between original and changeset data
       #
       # @return [TrueClass, FalseClass]
@@ -77,8 +67,9 @@ module ROM
       def diff
         @diff ||=
           begin
-            data_tuple = __data__.to_a
-            data_keys = __data__.keys & original.keys
+            data = to_h
+            data_tuple = data.to_a
+            data_keys = data.keys & original.keys
 
             new_tuple = data_tuple.to_a.select { |(k, _)| data_keys.include?(k) }
             ori_tuple = original.to_a.select { |(k, _)| data_keys.include?(k) }

--- a/lib/rom/repository/changeset/update.rb
+++ b/lib/rom/repository/changeset/update.rb
@@ -67,7 +67,7 @@ module ROM
       def diff
         @diff ||=
           begin
-            data = to_h
+            data = pipe.for_diff(__data__)
             data_tuple = data.to_a
             data_keys = data.keys & original.keys
 

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Using changesets' do
 
       changeset = repo
         .changeset(book.id, title: 'rom-rb is awesome for real')
-        .map(:touch)
+        .extend(:touch)
 
       expect(changeset.diff).to eql(title: 'rom-rb is awesome for real')
 
@@ -150,6 +150,7 @@ RSpec.describe 'Using changesets' do
 
       changeset = repo
         .changeset(book.id, title: 'rom-rb is awesome')
+        .extend(:touch)
 
       expect(changeset).to_not be_diff
 

--- a/spec/integration/changeset_spec.rb
+++ b/spec/integration/changeset_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Using changesets' do
     it 'preprocesses data using built-in steps and custom block' do
       changeset = repo.
                     changeset(:books, title: "rom-rb is awesome").
-                    map(:touch) { |tuple| tuple.merge(created_at: Time.now) }
+                    extend(:touch) { |tuple| tuple.merge(created_at: Time.now) }
 
       command = repo.command(:create, repo.books)
       result = command.(changeset)

--- a/spec/unit/changeset_spec.rb
+++ b/spec/unit/changeset_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe ROM::Changeset do
 
       expect(changeset).to_not be_diff
     end
+
+    it 'uses piped data for diff' do
+      expect(relation).to receive(:one).and_return(jane)
+
+      changeset = ROM::Changeset::Update.new(relation).data(name: "Jane").map { |name: | { name: name.upcase } }
+
+      expect(changeset).to be_diff
+    end
   end
 
   describe '#clean?' do


### PR DESCRIPTION
This breaks specs because result usually contains timestamp fields, thus diff
cannot be empty. We need to split piping in two steps I guess to fix this.

refs #89 