### PR TITLE
Support for generating auto-structs within a custom namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,5 @@ group :tools do
   gem 'mutant'
   gem 'mutant-rspec'
 end
+
+gem 'dry-core', git: 'https://github.com/dry-rb/dry-core.git', branch: 'feature/namespaced-class-builder'

--- a/Gemfile
+++ b/Gemfile
@@ -37,4 +37,4 @@ group :tools do
   gem 'mutant-rspec'
 end
 
-gem 'dry-core', git: 'https://github.com/dry-rb/dry-core.git', branch: 'feature/namespaced-class-builder'
+gem 'dry-core', git: 'https://github.com/dry-rb/dry-core.git'

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -82,9 +82,19 @@ module ROM
 
     auto_struct true
 
+    # @!method self.auto_struct
+    #   Get or set struct namespace
+    defines :struct_namespace
+
+    struct_namespace ROM::Struct
+
     # @!attribute [r] container
     #   @return [ROM::Container] The container used to set up a repo
     param :container, allow: ROM::Container
+
+    # @!attribute [r] struct_namespace
+    #   @return [Module,Class] The namespace for auto-generated structs
+    option :struct_namespace, default: -> { self.class.struct_namespace }
 
     # @!attribute [r] auto_struct
     #   @return [Boolean] The container used to set up a repo
@@ -111,7 +121,7 @@ module ROM
     def initialize(container, opts = EMPTY_HASH)
       super
 
-      @mappers = MapperBuilder.new
+      @mappers = MapperBuilder.new(struct_namespace: struct_namespace)
 
       @relations = RelationRegistry.new do |registry, relations|
         self.class.relations.each do |name|

--- a/lib/rom/repository.rb
+++ b/lib/rom/repository.rb
@@ -282,7 +282,7 @@ module ROM
     #   end
     #
     #   user
-    #   # => #<ROM::Struct[User] id=1 name="Jane">
+    #   # => #<ROM::Struct::User id=1 name="Jane">
     #
     # @example with a rollback
     #   user = transaction do |t|

--- a/lib/rom/repository/header_builder.rb
+++ b/lib/rom/repository/header_builder.rb
@@ -7,8 +7,8 @@ module ROM
     class HeaderBuilder
       attr_reader :struct_builder
 
-      def initialize(options = EMPTY_HASH)
-        @struct_builder = StructBuilder.new
+      def initialize(struct_namespace: nil, **options)
+        @struct_builder = StructBuilder.new(struct_namespace)
       end
 
       def call(ast)

--- a/lib/rom/repository/mapper_builder.rb
+++ b/lib/rom/repository/mapper_builder.rb
@@ -10,8 +10,8 @@ module ROM
 
       attr_reader :header_builder
 
-      def initialize
-        @header_builder = HeaderBuilder.new
+      def initialize(options = EMPTY_HASH)
+        @header_builder = HeaderBuilder.new(options)
       end
 
       def call(ast)

--- a/lib/rom/repository/struct_builder.rb
+++ b/lib/rom/repository/struct_builder.rb
@@ -30,6 +30,12 @@ module ROM
       end
       alias_method :[], :call
 
+      attr_reader :namespace
+
+      def initialize(namespace = nil)
+        @namespace = namespace || ROM::Struct
+      end
+
       private
 
       def visit(ast)
@@ -66,11 +72,11 @@ module ROM
       end
 
       def build_class(name, parent, &block)
-        Dry::Core::ClassBuilder.new(name: class_name(name), parent: parent).call(&block)
+        Dry::Core::ClassBuilder.new(name: class_name(name), parent: parent, namespace: namespace).call(&block)
       end
 
       def class_name(name)
-        "ROM::Struct[#{Dry::Core::Inflector.classify(Dry::Core::Inflector.singularize(name))}]"
+        Dry::Core::Inflector.classify(Dry::Core::Inflector.singularize(name))
       end
     end
   end

--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -45,6 +45,8 @@ module ROM
   #
   # @api public
   class Struct < Dry::Struct
+    MissingAttribute = Class.new(NameError)
+
     # Returns a short string representation
     #
     # @return [String]
@@ -65,15 +67,10 @@ module ROM
 
     private
 
-    def method_missing(m, *args)
-      inspected = inspect
-      trace = caller
-
-      # This is how MRI currently works
-      # see func name_err_mesg_to_str in error.c
-      name = inspected.size > 65 ? to_s : inspected
-
-      raise NoMethodError.new("undefined method `#{ m }' for #{ name }", m, args).tap { |e| e.set_backtrace(trace) }
+    def method_missing(*)
+      super
+    rescue NameError => error
+      raise MissingAttribute.new("#{ error.message } (not loaded attribute?)")
     end
   end
 end

--- a/lib/rom/struct.rb
+++ b/lib/rom/struct.rb
@@ -7,13 +7,20 @@ module ROM
   # They implement Hash protocol which means that they can be used
   # in places where Hash-like objects are supported.
   #
-  # Repositories define subclasses of ROM::Struct automatically, they are not
-  # defined as constants in any module, instead, generated mappers are configured
-  # to use anonymous struct classes as models.
+  # Repositories define subclasses of ROM::Struct automatically, they are
+  # defined in the ROM::Struct namespace by default, but you set it up
+  # to use your namespace/module as well.
   #
   # Structs are based on dry-struct gem, they include `schema` with detailed information
   # about attribute types returned from relations, thus can be introspected to build
   # additional functionality when desired.
+  #
+  # There is a caveat you should know about when working with structs. Struct classes
+  # have names but at the same time they're anonymous, i.e. you can't get the User struct class
+  # with ROM::Struct::User. ROM will create as many struct classes for User as needed,
+  # they all will have the same name and ROM::Struct::User will be the common parent class for
+  # them. Combined with the ability to provide your own namespace for structs this enables to
+  # pre-define the parent class.
   #
   # @example accessing relation struct model
   #   rom = ROM.container(:sql, 'sqlite::memory') do |conf|
@@ -30,7 +37,7 @@ module ROM
   #
   #   # get auto-generated User struct
   #   model = user_repo.users.mapper.model
-  #   # => ROM::Struct[User]
+  #   # => ROM::Struct::User
   #
   #   # see struct's schema attributes
   #
@@ -39,6 +46,24 @@ module ROM
   #
   #   model.schema[:name]
   #   # => #<Dry::Types::Sum left=#<Dry::Types::Constrained type=#<Dry::Types::Definition primitive=NilClass options={}> options={:rule=>#<Dry::Logic::Rule::Predicate predicate=#<Method: Module(Dry::Logic::Predicates::Methods)#type?> options={:args=>[NilClass]}>} rule=#<Dry::Logic::Rule::Predicate predicate=#<Method: Module(Dry::Logic::Predicates::Methods)#type?> options={:args=>[NilClass]}>> right=#<Dry::Types::Definition primitive=String options={}> options={:meta=>{:name=>:name, :source=>ROM::Relation::Name(users)}}>
+  #
+  # @example passing a namespace with an existing parent class
+  #   module Entities
+  #     class User < ROM::Struct
+  #       def upcased_name
+  #         name.upcase
+  #       end
+  #     end
+  #   end
+  #
+  #   class UserRepo < ROM::Repository[:users]
+  #     struct_namespace Entities
+  #   end
+  #
+  #   user_repo = UserRepo.new(rom)
+  #   user = user_repo.users.by_pk(1).one!
+  #   user.name # => "Jane"
+  #   user.upcased_name # => "JANE"
   #
   # @see http://dry-rb.org/gems/dry-struct dry-struct
   # @see http://dry-rb.org/gems/dry-types dry-types

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -238,6 +238,11 @@ RSpec.describe 'ROM repository' do
   end
 
   describe 'projecting virtual attributes' do
+    before do
+      ROM::Repository::StructBuilder.cache.clear
+      ROM::Repository::MapperBuilder.cache.clear
+    end
+
     shared_context 'auto-mapping' do
       it 'loads auto-mapped structs' do
         user = repo.users.

--- a/spec/integration/repository_spec.rb
+++ b/spec/integration/repository_spec.rb
@@ -238,17 +238,40 @@ RSpec.describe 'ROM repository' do
   end
 
   describe 'projecting virtual attributes' do
-    it 'loads auto-mapped structs' do
-      user = repo.users.
-               inner_join(:posts, author_id: :id).
-               select_group { [id.qualified, name.qualified] }.
-               select_append { int::count(:posts).as(:post_count) }.
-               having { count(id.qualified) >= 1 }.
-               first
+    shared_context 'auto-mapping' do
+      it 'loads auto-mapped structs' do
+        user = repo.users.
+                 inner_join(:posts, author_id: :id).
+                 select_group { [id.qualified, name.qualified] }.
+                 select_append { int::count(:posts).as(:post_count) }.
+                 having { count(id.qualified) >= 1 }.
+                 first
 
-      expect(user.id).to be(1)
-      expect(user.name).to eql('Jane')
-      expect(user.post_count).to be(1)
+        expect(user.id).to be(1)
+        expect(user.name).to eql('Jane')
+        expect(user.post_count).to be(1)
+      end
+    end
+
+    context 'with default namespace' do
+      include_context 'auto-mapping'
+    end
+
+    context 'with custom struct namespace' do
+      before do
+        repo_class.struct_namespace(Test)
+      end
+
+      include_context 'auto-mapping'
+
+      it 'uses custom namespace' do
+        expect(Test.const_defined?(:User)).to be(false)
+        user = repo.users.limit(1).one!
+
+        expect(user.name).to eql('Jane')
+        expect(user.class).to be < Test::User
+        expect(user.class.name).to eql(Test::User.name)
+      end
     end
   end
 

--- a/spec/unit/struct_builder_spec.rb
+++ b/spec/unit/struct_builder_spec.rb
@@ -70,32 +70,6 @@ RSpec.describe 'struct builder', '#call' do
                                         Dry::Struct::Error, /:name is missing/
                                       )
     end
-
-    context 'name errors' do
-      let(:struct) { builder.class.cache[input.hash] }
-
-      context 'missing method on instance' do
-        it 'uses inspect and class name for small structs' do
-          user = struct.new(id: 1, name: 'Jane')
-
-          expect { user.missing }.
-            to raise_error(
-                 NoMethodError,
-                 %r{undefined method `missing' for #<ROM::Struct::User id=1 name="Jane">}
-               )
-        end
-
-        it 'uses class name in name errors' do
-          user = struct.new(id: 1, name: 'J' * 50)
-
-          expect { user.missing }.
-            to raise_error(
-                 NoMethodError,
-                 %r{undefined method `missing' for #<ROM::Struct::User:0x\h+>}
-               )
-        end
-      end
-    end
   end
 
   context 'custom entity container' do
@@ -126,6 +100,23 @@ RSpec.describe 'struct builder', '#call' do
       user = struct.new(id: 1, name: 'Jane')
 
       expect(user.upcased_name).to eql('JANE')
+    end
+
+    it 'raises a nice error on missing attributes' do
+      class Test::Custom::User < ROM::Struct
+        def upcased_middle_name
+          middle_name.upcase
+        end
+      end
+
+      user = struct.new(id: 1, name: 'Jane')
+
+      expect {
+        user.upcased_middle_name
+      }.to raise_error(
+             ROM::Struct::MissingAttribute,
+             /not loaded attribute\?/
+           )
     end
   end
 end

--- a/spec/unit/struct_builder_spec.rb
+++ b/spec/unit/struct_builder_spec.rb
@@ -18,81 +18,114 @@ RSpec.describe 'struct builder', '#call' do
                 [:attribute, attr_double(:name, :String)]]]]
   end
 
-  before { builder[*input] }
+  context 'ROM::Struct' do
+    before { builder[*input] }
 
-  it 'generates a struct for a given relation name and columns' do
-    struct = builder.class.cache[input.hash]
-
-    user = struct.new(id: 1, name: 'Jane')
-
-    expect(user.id).to be(1)
-    expect(user.name).to eql('Jane')
-
-    expect(user[:id]).to be(1)
-    expect(user[:name]).to eql('Jane')
-
-    expect(Hash[user]).to eql(id: 1, name: 'Jane')
-
-    expect(user.inspect).to eql('#<ROM::Struct[User] id=1 name="Jane">')
-    expect(user.to_s).to match(/\A#<ROM::Struct\[User\]:0x[0-9a-f]+>\z/)
-  end
-
-  it 'stores struct in the cache' do
-    expect(builder.class.cache[input.hash]).to be(builder[*input])
-  end
-
-  context 'with reserved keywords as attribute names' do
-    let(:input) do
-      [:users, [:header, [
-                  [:attribute, attr_double(:id, :Int)],
-                  [:attribute, attr_double(:name, :String)],
-                  [:attribute, attr_double(:alias, :String)],
-                  [:attribute, attr_double(:until, :Time)]]]]
-    end
-
-    it 'allows to build a struct class without complaining' do
+    it 'generates a struct for a given relation name and columns' do
       struct = builder.class.cache[input.hash]
 
-      user = struct.new(id: 1, name: 'Jane', alias: 'JD', until: Time.new(2030))
+      user = struct.new(id: 1, name: 'Jane')
 
       expect(user.id).to be(1)
       expect(user.name).to eql('Jane')
-      expect(user.alias).to eql('JD')
-      expect(user.until).to eql(Time.new(2030))
+
+      expect(user[:id]).to be(1)
+      expect(user[:name]).to eql('Jane')
+
+      expect(Hash[user]).to eql(id: 1, name: 'Jane')
+
+      expect(user.inspect).to eql('#<ROM::Struct::User id=1 name="Jane">')
+      expect(user.to_s).to match(/\A#<ROM::Struct::User:0x[0-9a-f]+>\z/)
+    end
+
+    it 'stores struct in the cache' do
+      expect(builder.class.cache[input.hash]).to be(builder[*input])
+    end
+
+    context 'with reserved keywords as attribute names' do
+      let(:input) do
+        [:users, [:header, [
+                    [:attribute, attr_double(:id, :Int)],
+                    [:attribute, attr_double(:name, :String)],
+                    [:attribute, attr_double(:alias, :String)],
+                    [:attribute, attr_double(:until, :Time)]]]]
+      end
+
+      it 'allows to build a struct class without complaining' do
+        struct = builder.class.cache[input.hash]
+
+        user = struct.new(id: 1, name: 'Jane', alias: 'JD', until: Time.new(2030))
+
+        expect(user.id).to be(1)
+        expect(user.name).to eql('Jane')
+        expect(user.alias).to eql('JD')
+        expect(user.until).to eql(Time.new(2030))
+      end
+    end
+
+    it 'raise a friendly error on missing keys' do
+      struct = builder.class.cache[input.hash]
+
+      expect { struct.new(id: 1) }.to raise_error(
+                                        Dry::Struct::Error, /:name is missing/
+                                      )
+    end
+
+    context 'name errors' do
+      let(:struct) { builder.class.cache[input.hash] }
+
+      context 'missing method on instance' do
+        it 'uses inspect and class name for small structs' do
+          user = struct.new(id: 1, name: 'Jane')
+
+          expect { user.missing }.
+            to raise_error(
+                 NoMethodError,
+                 %r{undefined method `missing' for #<ROM::Struct::User id=1 name="Jane">}
+               )
+        end
+
+        it 'uses class name in name errors' do
+          user = struct.new(id: 1, name: 'J' * 50)
+
+          expect { user.missing }.
+            to raise_error(
+                 NoMethodError,
+                 %r{undefined method `missing' for #<ROM::Struct::User:0x\h+>}
+               )
+        end
+      end
     end
   end
 
-  it 'raise a friendly error on missing keys' do
-    struct = builder.class.cache[input.hash]
+  context 'custom entity container' do
+    before do
+      module Test
+        module Custom
+        end
+      end
+    end
 
-    expect { struct.new(id: 1) }.to raise_error(
-      Dry::Struct::Error, /:name is missing/
-    )
-  end
+    let(:struct) { builder[*input] }
+    subject(:builder) { ROM::Repository::StructBuilder.new(Test::Custom) }
 
-  context 'name errors' do
-    let(:struct) { builder.class.cache[input.hash] }
+    it 'generates a struct class inside a given module' do
+      expect(struct.name).to eql('Test::Custom::User')
+      user = struct.new(id: 1, name: 'Jane')
 
-    context 'missing method on instance' do
-      it 'uses inspect and class name for small structs' do
-        user = struct.new(id: 1, name: 'Jane')
+      expect(user.inspect).to eql(%q{#<Test::Custom::User id=1 name="Jane">})
+    end
 
-        expect { user.missing }.
-          to raise_error(
-               NoMethodError,
-               %r{undefined method `missing' for #<ROM::Struct\[User\] id=1 name="Jane">}
-             )
+    it 'uses the existing class as a parent' do
+      class Test::Custom::User < ROM::Struct
+        def upcased_name
+          name.upcase
+        end
       end
 
-      it 'uses class name in name errors' do
-        user = struct.new(id: 1, name: 'J' * 50)
+      user = struct.new(id: 1, name: 'Jane')
 
-        expect { user.missing }.
-          to raise_error(
-               NoMethodError,
-               %r{undefined method `missing' for #<ROM::Struct\[User\]:0x\h+>}
-             )
-      end
+      expect(user.upcased_name).to eql('JANE')
     end
   end
 end


### PR DESCRIPTION
This makes it possible

```ruby
module Entities
  class User < ROM::Struct
    def name
      [first_name, last_name].join('  ')
    end
  end
end

class UserRepo < ROM::Repository[:users]
  struct_namespace Entities
end

user = UserRepo.new(rom).users.by_pk(1).one!
user.name # => "John Doe"
user.class.name # => "Entities::User"
user.class == Entities::User # => false
user.class.superclass == Entities::User # => true
```

@solnic what do you think about this? This works like a charm, however, auto-generated classes will share the same name but won't be actually the same class. This can lead to confusion and must be covered in the docs. And it also looks like that naming hack doesn't work on MRI <= 2.3, we have to go with the previous code on old rubies.